### PR TITLE
회원가입 오류 처리, 프로필 사진 Storage 연동

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     implementation 'com.facebook.android:facebook-login:4.39.0'
     //firebase realtime database
     implementation 'com.google.firebase:firebase-database:16.0.5'
+    //firebase storage
+    implementation 'com.google.firebase:firebase-storage:16.0.5'
     //glide
     implementation 'com.github.bumptech.glide:glide:4.8.0'
     implementation 'jp.wasabeef:glide-transformations:4.0.0'

--- a/app/src/main/java/com/boostcampa2/catchhouse/constants/Constants.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/constants/Constants.java
@@ -6,7 +6,7 @@ public class Constants {
     public enum SignInRequestCode {
         GOOGLE_SIGN_IN(1000), FACEBOOK_SIGN_IN(1001), E_MAIL_SIGN_IN(10002);
 
-        final private int requestCode;
+        private final int requestCode;
 
         SignInRequestCode(int requestCode) {
             this.requestCode = requestCode;
@@ -17,5 +17,16 @@ public class Constants {
         }
     }
 
-    public static int GALLERY = 1003;
+    public static final int GALLERY = 1003;
+
+    //gender
+    public static final String MALE = "male";
+    public static final String FEMALE = "female";
+
+    //facebook readPermissions
+    public static final String E_MAIL = "email";
+    public static final String PUBLIC_PROFILE = "public_profile";
+
+    //success code
+    public static final String SIGN_IN_SUCCESS = "signInSuccess";
 }

--- a/app/src/main/java/com/boostcampa2/catchhouse/constants/Constants.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/constants/Constants.java
@@ -29,4 +29,6 @@ public class Constants {
 
     //success code
     public static final String SIGN_IN_SUCCESS = "signInSuccess";
+    public static final String SIGN_IN_FAILED = "signInFailed";
+    public static final String SIGN_UP_SUCCESS = "signUpSuccess";
 }

--- a/app/src/main/java/com/boostcampa2/catchhouse/data/userdata/UserRepository.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/data/userdata/UserRepository.java
@@ -1,5 +1,6 @@
 package com.boostcampa2.catchhouse.data.userdata;
 
+import android.net.Uri;
 import android.support.annotation.NonNull;
 
 import com.boostcampa2.catchhouse.data.userdata.pojo.User;
@@ -38,5 +39,10 @@ public class UserRepository {
     @NonNull
     public Completable setUserToRemote(String uuid, User user) {
         return mUserRemote.setUser(uuid, user);
+    }
+
+    @NonNull
+    public Single<Uri> saveProfileAndGetUrl(String uuid, byte[] profileByreArray) {
+        return mUserRemote.saveProfileAndGetUrl(uuid, profileByreArray);
     }
 }

--- a/app/src/main/java/com/boostcampa2/catchhouse/view/activities/BottomNavActivity.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/view/activities/BottomNavActivity.java
@@ -1,13 +1,13 @@
 package com.boostcampa2.catchhouse.view.activities;
 
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentManager;
-import android.util.Log;
 import android.view.MenuItem;
-import android.widget.Toast;
+import android.view.View;
+import android.view.WindowManager;
 
 import com.boostcampa2.catchhouse.R;
-import com.boostcampa2.catchhouse.constants.Constants;
 import com.boostcampa2.catchhouse.data.userdata.UserRepository;
 import com.boostcampa2.catchhouse.databinding.ActivityBottomNavBinding;
 import com.boostcampa2.catchhouse.view.BaseActivity;
@@ -15,12 +15,18 @@ import com.boostcampa2.catchhouse.view.fragments.SignInFragment;
 import com.boostcampa2.catchhouse.viewmodel.ViewModelListener;
 import com.boostcampa2.catchhouse.viewmodel.userviewmodel.UserViewModel;
 import com.boostcampa2.catchhouse.viewmodel.userviewmodel.UserViewModelFactory;
+import com.bumptech.glide.load.engine.GlideException;
+import com.facebook.FacebookException;
+import com.google.android.gms.auth.GoogleAuthException;
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
+import com.google.firebase.auth.FirebaseAuthUserCollisionException;
 
 import io.reactivex.Single;
 import io.reactivex.disposables.CompositeDisposable;
 
 import static com.boostcampa2.catchhouse.constants.Constants.SIGN_IN_SUCCESS;
+import static com.boostcampa2.catchhouse.constants.Constants.SIGN_UP_SUCCESS;
 
 public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> implements ViewModelListener {
 
@@ -34,24 +40,53 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
 
     @Override
     public void onError(Throwable throwable) {
-        Toast.makeText(this, throwable.toString(), Toast.LENGTH_SHORT).show();
+        unFreezeUI();
+        if (throwable instanceof FirebaseAuthInvalidCredentialsException) {
+            Snackbar.make(getBinding().getRoot(), R.string.snack_invalid_user, Snackbar.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (throwable instanceof FirebaseAuthUserCollisionException) {
+            Snackbar.make(getBinding().getRoot(), R.string.snack_already_exist_email, Snackbar.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (throwable instanceof GlideException) {
+            Snackbar.make(getBinding().getRoot(), R.string.snack_failed_load_image, Snackbar.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (throwable instanceof FacebookException || throwable instanceof GoogleAuthException) {
+            Snackbar.make(getBinding().getRoot(), R.string.snack_fb_sign_in_failed, Snackbar.LENGTH_SHORT).show();
+            return;
+        }
+
+        Snackbar.make(getBinding().getRoot(), R.string.snack_failed_sign_up, Snackbar.LENGTH_SHORT).show();
+
     }
 
     @Override
     public void onSuccess(String success) {
+        unFreezeUI();
         switch (success) {
+            case SIGN_UP_SUCCESS:
+                mFragmentManager.popBackStack();
+                break;
             case SIGN_IN_SUCCESS:
-
+                /*handle here : when sign in success replace fragment to my page*/
+                Snackbar.make(getBinding().getRoot(), "로그인 성공", Snackbar.LENGTH_SHORT).show();
                 break;
         }
     }
 
     @Override
     public void isWorking() {
+        freezeUI();
     }
 
     @Override
     public void isFinished() {
+        unFreezeUI();
     }
 
     @Override
@@ -61,12 +96,11 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
         createViewModes();
         mDisposable = new CompositeDisposable();
         mFragmentManager = getSupportFragmentManager();
-        getBinding().bnavHomeActivity.setItemIconTintList(null);
-        getBinding().bnavHomeActivity.setOnNavigationItemSelectedListener(v -> {
+        getBinding().bottomNav.setItemIconTintList(null);
+        getBinding().bottomNav.setOnNavigationItemSelectedListener(v -> {
             onNavItemSelected(v);
             return true;
         });
-
     }
 
     private void createViewModes() {
@@ -89,7 +123,7 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
                             break;
                         case R.id.action_my_page:
                             if (FirebaseAuth.getInstance().getCurrentUser() == null) {
-                                mFragmentManager.beginTransaction().replace(R.id.fl_home_container, new SignInFragment()).commit();
+                                mFragmentManager.beginTransaction().replace(R.id.fl_bottom_nav_container, new SignInFragment()).commit();
                                 return;
                             }
                             break;
@@ -108,5 +142,17 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
     protected void onStop() {
         super.onStop();
         mDisposable.dispose();
+    }
+
+    private void freezeUI() {
+        getBinding().pgBottomNav.setVisibility(View.VISIBLE);
+        getBinding().getRoot().setAlpha(0.6f);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE, WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE);
+    }
+
+    private void unFreezeUI() {
+        getBinding().pgBottomNav.setVisibility(View.GONE);
+        getBinding().getRoot().setAlpha(1.0f);
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE);
     }
 }

--- a/app/src/main/java/com/boostcampa2/catchhouse/view/activities/BottomNavActivity.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/view/activities/BottomNavActivity.java
@@ -7,6 +7,7 @@ import android.view.MenuItem;
 import android.widget.Toast;
 
 import com.boostcampa2.catchhouse.R;
+import com.boostcampa2.catchhouse.constants.Constants;
 import com.boostcampa2.catchhouse.data.userdata.UserRepository;
 import com.boostcampa2.catchhouse.databinding.ActivityBottomNavBinding;
 import com.boostcampa2.catchhouse.view.BaseActivity;
@@ -14,9 +15,12 @@ import com.boostcampa2.catchhouse.view.fragments.SignInFragment;
 import com.boostcampa2.catchhouse.viewmodel.ViewModelListener;
 import com.boostcampa2.catchhouse.viewmodel.userviewmodel.UserViewModel;
 import com.boostcampa2.catchhouse.viewmodel.userviewmodel.UserViewModelFactory;
+import com.google.firebase.auth.FirebaseAuth;
 
 import io.reactivex.Single;
 import io.reactivex.disposables.CompositeDisposable;
+
+import static com.boostcampa2.catchhouse.constants.Constants.SIGN_IN_SUCCESS;
 
 public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> implements ViewModelListener {
 
@@ -31,17 +35,23 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
     @Override
     public void onError(Throwable throwable) {
         Toast.makeText(this, throwable.toString(), Toast.LENGTH_SHORT).show();
-        Log.d("에러", "onError: " + throwable.toString());
+    }
+
+    @Override
+    public void onSuccess(String success) {
+        switch (success) {
+            case SIGN_IN_SUCCESS:
+
+                break;
+        }
     }
 
     @Override
     public void isWorking() {
-        Toast.makeText(this, "일합니다.", Toast.LENGTH_SHORT).show();
     }
 
     @Override
     public void isFinished() {
-        Toast.makeText(this, "끝", Toast.LENGTH_SHORT).show();
     }
 
     @Override
@@ -78,10 +88,20 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
                             /* handle here: replace fragment on message btn Clicked */
                             break;
                         case R.id.action_my_page:
-                            mFragmentManager.beginTransaction().replace(R.id.fl_home_container, new SignInFragment()).commit();
+                            if (FirebaseAuth.getInstance().getCurrentUser() == null) {
+                                mFragmentManager.beginTransaction().replace(R.id.fl_home_container, new SignInFragment()).commit();
+                                return;
+                            }
                             break;
                     }
                 }));
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        FirebaseAuth.getInstance().signOut();
+
     }
 
     @Override

--- a/app/src/main/java/com/boostcampa2/catchhouse/view/activities/BottomNavActivity.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/view/activities/BottomNavActivity.java
@@ -134,8 +134,9 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
     @Override
     protected void onStart() {
         super.onStart();
-        FirebaseAuth.getInstance().signOut();
-
+        if(FirebaseAuth.getInstance().getCurrentUser() != null) {
+            /* User is logined. hadle here*/
+        }
     }
 
     @Override

--- a/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignInFragment.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignInFragment.java
@@ -1,12 +1,13 @@
 package com.boostcampa2.catchhouse.view.fragments;
 
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentManager;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,6 +20,9 @@ import com.boostcampa2.catchhouse.viewmodel.userviewmodel.UserViewModel;
 import com.facebook.CallbackManager;
 
 import java.util.Arrays;
+
+import static com.boostcampa2.catchhouse.constants.Constants.E_MAIL;
+import static com.boostcampa2.catchhouse.constants.Constants.PUBLIC_PROFILE;
 
 public class SignInFragment extends BaseFragment<FragmentSignInBinding, UserViewModel> {
 
@@ -51,30 +55,46 @@ public class SignInFragment extends BaseFragment<FragmentSignInBinding, UserView
         getBinding().setHandler(getViewModel());
         getBinding().setLifecycleOwner(getActivity());
 
+        getBinding().tvSignInLogin.setOnClickListener(v -> {
+            if (signInInfoCheck()) {
+                Snackbar.make(v, R.string.snack_fill_info, Snackbar.LENGTH_SHORT);
+                return;
+            }
+            mViewModel.signInWithEmail();
+        });
+
         getBinding().ivSignInGoogle.setOnClickListener(__ ->
-                startActivityForResult(getViewModel().requestGoogleSignIn().getSignInIntent(), Constants.SignInRequestCode.GOOGLE_SIGN_IN.getRequestCode()));
+                startActivityForResult(getViewModel().gettGoogleSignInIntent(), Constants.SignInRequestCode.GOOGLE_SIGN_IN.getRequestCode()));
 
         getBinding().ivSignInFacebook.setOnClickListener(__ -> {
             mCallbackManager = CallbackManager.Factory.create();
             getViewModel().requestFacebookSignIn(mCallbackManager)
-                    .logInWithReadPermissions(this, Arrays.asList("email", "public_profile", "user_gender", "user_photos"));
+                    .logInWithReadPermissions(this, Arrays.asList(E_MAIL, PUBLIC_PROFILE));
         });
 
-        getBinding().ivSignInEmail.setOnClickListener(__ -> mFragmentManager.beginTransaction()
-                .replace(R.id.fl_home_container, new SignUpFragment())
-                .addToBackStack(SignUpFragment.class.getName()).commit());
-
-        getViewModel().getUserInfo().observe(this, v -> Log.d("파베", v.getEmail()));
+        getBinding().ivSignInEmail.setOnClickListener(__ ->
+                mFragmentManager
+                        .beginTransaction()
+                        .replace(R.id.fl_home_container, new SignUpFragment())
+                        .addToBackStack(SignUpFragment.class.getName())
+                        .commit());
     }
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == Constants.SignInRequestCode.GOOGLE_SIGN_IN.getRequestCode()) {
-            getViewModel().signUpFirebaseWithGoogle(data);
+            if (resultCode == Activity.RESULT_OK) {
+                getViewModel().signUpFirebaseWithGoogle(data);
+            }
             return;
         }
         mCallbackManager.onActivityResult(requestCode, resultCode, data);
+    }
+
+    private boolean signInInfoCheck() {
+        return getBinding().etSignInEmail.getText().toString().trim().equals("") &&
+                getBinding().etSignInPassword.getText().toString().trim().equals("");
     }
 
 }

--- a/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignInFragment.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignInFragment.java
@@ -75,7 +75,7 @@ public class SignInFragment extends BaseFragment<FragmentSignInBinding, UserView
         getBinding().ivSignInEmail.setOnClickListener(__ ->
                 mFragmentManager
                         .beginTransaction()
-                        .replace(R.id.fl_home_container, new SignUpFragment())
+                        .replace(R.id.fl_bottom_nav_container, new SignUpFragment())
                         .addToBackStack(SignUpFragment.class.getName())
                         .commit());
     }

--- a/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignInFragment.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignInFragment.java
@@ -64,7 +64,7 @@ public class SignInFragment extends BaseFragment<FragmentSignInBinding, UserView
         });
 
         getBinding().ivSignInGoogle.setOnClickListener(__ ->
-                startActivityForResult(getViewModel().gettGoogleSignInIntent(), Constants.SignInRequestCode.GOOGLE_SIGN_IN.getRequestCode()));
+                startActivityForResult(getViewModel().getGoogleSignInIntent(), Constants.SignInRequestCode.GOOGLE_SIGN_IN.getRequestCode()));
 
         getBinding().ivSignInFacebook.setOnClickListener(__ -> {
             mCallbackManager = CallbackManager.Factory.create();

--- a/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignUpFragment.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignUpFragment.java
@@ -46,7 +46,7 @@ public class SignUpFragment extends BaseFragment<FragmentSignUpBinding, UserView
         super.onViewCreated(view, savedInstanceState);
 
         getBinding().setHandler(getViewModel());
-        getBinding().setLifecycleOwner(this);
+        getBinding().setLifecycleOwner(getActivity());
 
         getBinding().ivSignUpProfile.setOnClickListener(__ -> {
             Intent intent = new Intent(Intent.ACTION_PICK);
@@ -68,7 +68,6 @@ public class SignUpFragment extends BaseFragment<FragmentSignUpBinding, UserView
 
         getBinding().tvSignUp.setOnClickListener(v -> {
             if (signUpInfoCheck()) {
-                Snackbar.make(v, R.string.snack_fill_info, Snackbar.LENGTH_SHORT).show();
                 return;
             }
             getViewModel().signUpWithEmail();
@@ -76,8 +75,17 @@ public class SignUpFragment extends BaseFragment<FragmentSignUpBinding, UserView
     }
 
     private boolean signUpInfoCheck() {
-        return getBinding().etSignUpEmail.getText().toString().trim().equals("") && getBinding().etSignUpPassword.getText().toString().trim().equals("") &&
-                getBinding().etSignUpNickName.getText().toString().trim().equals("");
+        if (getBinding().etSignUpPassword.getText().toString().length() < 6) {
+            Snackbar.make(getBinding().getRoot(), getString(R.string.snack_wrong_password_length), Snackbar.LENGTH_SHORT).show();
+            return true;
+        }
+        if (getBinding().etSignUpEmail.getText().toString().trim().equals("")
+                && getBinding().etSignUpPassword.getText().toString().trim().equals("")
+                && getBinding().etSignUpNickName.getText().toString().trim().equals("")) {
+            Snackbar.make(getBinding().getRoot(), getString(R.string.snack_fill_info), Snackbar.LENGTH_SHORT).show();
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignUpFragment.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/view/fragments/SignUpFragment.java
@@ -3,7 +3,6 @@ package com.boostcampa2.catchhouse.view.fragments;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
@@ -17,7 +16,9 @@ import com.boostcampa2.catchhouse.view.BaseFragment;
 import com.boostcampa2.catchhouse.viewmodel.userviewmodel.UserViewModel;
 
 import static android.app.Activity.RESULT_OK;
+import static com.boostcampa2.catchhouse.constants.Constants.FEMALE;
 import static com.boostcampa2.catchhouse.constants.Constants.GALLERY;
+import static com.boostcampa2.catchhouse.constants.Constants.MALE;
 
 public class SignUpFragment extends BaseFragment<FragmentSignUpBinding, UserViewModel> {
 
@@ -55,19 +56,19 @@ public class SignUpFragment extends BaseFragment<FragmentSignUpBinding, UserView
 
         getBinding().rbSignUpMale.setOnCheckedChangeListener((__, isChecked) -> {
             if (isChecked) {
-                mViewModel.setGender("male");
+                mViewModel.setGender(MALE);
             }
         });
 
         getBinding().rbSignUpFemale.setOnCheckedChangeListener((__, isChecked) -> {
             if (isChecked) {
-                mViewModel.setGender("female");
+                mViewModel.setGender(FEMALE);
             }
         });
 
         getBinding().tvSignUp.setOnClickListener(v -> {
             if (signUpInfoCheck()) {
-                Snackbar.make(v, "모든 정보를 입력해 주세요", Snackbar.LENGTH_SHORT).show();
+                Snackbar.make(v, R.string.snack_fill_info, Snackbar.LENGTH_SHORT).show();
                 return;
             }
             getViewModel().signUpWithEmail();
@@ -87,7 +88,7 @@ public class SignUpFragment extends BaseFragment<FragmentSignUpBinding, UserView
                 getViewModel().getBitmapFromData(data.getData());
                 return;
             }
-            Snackbar.make(getBinding().getRoot(), "이미지 로드에 실패했습니다.", Snackbar.LENGTH_SHORT);
+            Snackbar.make(getBinding().getRoot(), R.string.snack_failed_load_image, Snackbar.LENGTH_SHORT);
         }
     }
 }

--- a/app/src/main/java/com/boostcampa2/catchhouse/viewmodel/ViewModelListener.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/viewmodel/ViewModelListener.java
@@ -4,6 +4,8 @@ public interface ViewModelListener {
 
     void onError(Throwable throwable);
 
+    void onSuccess(String success);
+
     void isWorking();
 
     void isFinished();

--- a/app/src/main/java/com/boostcampa2/catchhouse/viewmodel/userviewmodel/UserViewModel.java
+++ b/app/src/main/java/com/boostcampa2/catchhouse/viewmodel/userviewmodel/UserViewModel.java
@@ -33,6 +33,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
 import static com.boostcampa2.catchhouse.constants.Constants.SIGN_IN_SUCCESS;
+import static com.boostcampa2.catchhouse.constants.Constants.SIGN_UP_SUCCESS;
 
 public class UserViewModel extends ReactiveViewModel {
 
@@ -88,6 +89,7 @@ public class UserViewModel extends ReactiveViewModel {
     }
 
     public void signUpFirebaseWithGoogle(Intent data) {
+        mListener.isWorking();
         Task<GoogleSignInAccount> task = GoogleSignIn.getSignedInAccountFromIntent(data);
         GoogleSignInAccount account = task.getResult();
         mUser = new User(account.getDisplayName());
@@ -135,7 +137,7 @@ public class UserViewModel extends ReactiveViewModel {
                     mUser = new User(mEmail.getValue(), mNickName.getValue(), mGender.getValue());
                     mFirebaseUser.setValue(authResult.getUser());
                     getCompositeDisposable().add(mRepository.setUserToRemote(mFirebaseUser.getValue().getUid(), mUser)
-                            .subscribe(() -> mListener.isFinished(), error -> mListener.onError(error)));
+                            .subscribe(() -> mListener.onSuccess(SIGN_UP_SUCCESS), error -> mListener.onError(error)));
                 }).addOnFailureListener(error -> mListener.onError(error));
     }
 
@@ -152,14 +154,11 @@ public class UserViewModel extends ReactiveViewModel {
             String uuid = auth.getCurrentUser().getUid();
             getCompositeDisposable().add(mRepository.setUserToRemote(uuid, mUser)
                     .subscribe(() -> {
-                        mListener.isFinished();
+                        mListener.onSuccess(SIGN_IN_SUCCESS);
                         mFirebaseUser.setValue(auth.getCurrentUser());
                     }, error -> mListener.onError(error)));
         })
-                .addOnFailureListener(error -> {
-                    mListener.isFinished();
-                    mListener.onError(error);
-                });
+                .addOnFailureListener(error -> mListener.onError(error));
     }
 
     public LiveData<FirebaseUser> getUserInfo() {

--- a/app/src/main/res/layout/activity_bottom_nav.xml
+++ b/app/src/main/res/layout/activity_bottom_nav.xml
@@ -11,14 +11,14 @@
         android:layout_height="match_parent">
 
         <FrameLayout
-            android:id="@+id/fl_home_container"
+            android:id="@+id/fl_bottom_nav_container"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@id/bnav_home_activity"
+            app:layout_constraintBottom_toTopOf="@id/bottom_nav"
             app:layout_constraintTop_toTopOf="parent" />
 
         <android.support.design.widget.BottomNavigationView
-            android:id="@+id/bnav_home_activity"
+            android:id="@+id/bottom_nav"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@android:color/white"
@@ -30,6 +30,16 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:menu="@menu/bottom_nav_item_menu" />
+
+        <ProgressBar
+            android:id="@+id/pg_bottom_nav"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"/>
 
     </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_sign_up.xml
+++ b/app/src/main/res/layout/fragment_sign_up.xml
@@ -118,6 +118,7 @@
                 android:textColor="@android:color/white"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_sign_up_gender"
                 app:layout_constraintStart_toStartOf="parent" />
 
         </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,5 +16,7 @@
     <string name="sign_up_nick_name">NickName</string>
     <string name="sign_up_gender">Gender</string>
     <string name="sign_up">회원 가입</string>
+    <string name="snack_fill_info">모든 정보를 입력해 주세요</string>
+    <string name="snack_failed_load_image">이미지 로드에 실패했습니다.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,5 +18,11 @@
     <string name="sign_up">회원 가입</string>
     <string name="snack_fill_info">모든 정보를 입력해 주세요</string>
     <string name="snack_failed_load_image">이미지 로드에 실패했습니다.</string>
+    <string name="snack_incorrect_email">이메일 형식을 정확히 입력해주세요</string>
+    <string name="snack_already_exist_email">이미 존재하는 이메일 입니다.</string>
+    <string name="snack_wrong_password_length">비밀번호를 6자리 이상 설정해주세요</string>
+    <string name="snack_fb_sign_in_failed">로그인에 실패했습니다.</string>
+    <string name="snack_failed_sign_up">회원가입에 실패했습니다.</string>
+    <string name="snack_invalid_user">아이디 비밀번호를 확인하세요</string>
 
 </resources>


### PR DESCRIPTION
## 개요
* 회원 가입 오류 시, UI 처리 및, 유저 데이터 처리
* 프로필 사진 Storage 연동

## 구현사항
* 회원가입 오류 발생 시, 스낵바를 이용하여, 오류 내용과 실패 결과 알림
* Firebase Auth에 가입 성공 후, Storage, Database에 write하는 순서로 진행
* Firebase Auth에 가입 성공 후, Storage, Database에서 오류 발생 시, Firebase Auth 탈퇴 및, storage, db 삭제
* 이메일 회원 가입시, 프로필 사진을 선택하면, Storage에 저장 및 url 주소, db write

## 리뷰 요청 사항
* RxJava를 처음 사용해 보아서, 코드가 복잡하게 보이는 것 같습니다.
* 특히, 프로필 사진 저장 시, Firebase Auth -> Stoarge -> Storage url획득 -> Database write의 과정을 거쳐, 코드 읽기 힘든 것 같습니다. 더 나은 방법을 찾고 싶습니다.

resolve #8 