### PR TITLE
ChattingListFragment 오류 수정 및, 함수 리팩토링

### DIFF
--- a/app/src/main/java/com/swsnack/catchhouse/adapters/BaseDiffUtil.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapters/BaseDiffUtil.java
@@ -26,6 +26,6 @@ public abstract class BaseDiffUtil<T> extends DiffUtil.Callback {
 
     @Override
     public boolean areItemsTheSame(int i, int i1) {
-        return mOldList.get(i) == mNewList.get(i);
+        return mOldList.get(i) == mNewList.get(i1);
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/adapters/chattingadapter/ChattingListAdapter.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapters/chattingadapter/ChattingListAdapter.java
@@ -34,7 +34,6 @@ public class ChattingListAdapter extends BaseRecyclerViewAdapter<Chatting, Chatt
     public void onViewAttachedToWindow(@NonNull RecyclerView.ViewHolder holder) {
         super.onViewAttachedToWindow(holder);
         ((ChattingItemHolder) holder).onAttachHolder();
-
     }
 
     @Override

--- a/app/src/main/java/com/swsnack/catchhouse/constants/Constants.java
+++ b/app/src/main/java/com/swsnack/catchhouse/constants/Constants.java
@@ -1,6 +1,5 @@
 package com.swsnack.catchhouse.constants;
 
-import android.support.annotation.IntDef;
 import android.support.annotation.StringDef;
 
 import java.lang.annotation.Retention;
@@ -8,9 +7,11 @@ import java.lang.annotation.RetentionPolicy;
 
 import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.DELETED_USER;
 import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.DELETE_EXCEPTION;
+import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.DUPLICATE;
 import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.DUPLICATE_EMAIL;
 import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.DUPLICATE_NICK_NAME;
 import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.FAILED_LOAD_IMAGE;
+import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.FAILED_UPDATE;
 import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.IN_SUFFICIENT_INFO;
 import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.MISMATCH_USER_INFO;
 import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.NOT_SIGNED_USER;
@@ -87,7 +88,7 @@ public class Constants {
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({IN_SUFFICIENT_INFO, SHORT_PASSWORD, DUPLICATE_EMAIL, MISMATCH_USER_INFO,
             FAILED_LOAD_IMAGE, SIGN_IN_EXCEPTION, SIGN_UP_EXCEPTION, NOT_SIGNED_USER, DELETED_USER,
-            SAME_NICK_NAME, DUPLICATE_NICK_NAME, DELETE_EXCEPTION})
+            SAME_NICK_NAME, DUPLICATE_NICK_NAME, DELETE_EXCEPTION, DUPLICATE, FAILED_UPDATE})
     public @interface ExceptionReason {
         String IN_SUFFICIENT_INFO = "InSufficientInfo";
         String SHORT_PASSWORD = "shortPassword";
@@ -100,7 +101,9 @@ public class Constants {
         String DELETE_EXCEPTION = "deleteException";
         String DELETED_USER = "deletedUser";
         String SAME_NICK_NAME = "sameNickName";
+        String DUPLICATE = "duplicate";
         String DUPLICATE_NICK_NAME = "duplicateNickName";
+        String FAILED_UPDATE = "failedUpdate";
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -6,7 +6,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.facebook.AccessToken;
-import com.facebook.GraphRequest;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.FirebaseException;
@@ -169,8 +168,8 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void getUserInfoFromFacebook(@NonNull AccessToken accessToken, @NonNull GraphRequest.GraphJSONObjectCallback facebookUserDataCallback) {
-        mApiManager.getUserInfoFromFacebook(accessToken, facebookUserDataCallback);
+    public void getUserInfoFromFacebook(@NonNull AccessToken accessToken, @NonNull OnSuccessListener<User> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+        mApiManager.getUserInfoFromFacebook(accessToken, onSuccessListener, onFailureListener);
     }
 
     @Override

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/remote/RemoteChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/remote/RemoteChattingManager.java
@@ -47,6 +47,7 @@ public class RemoteChattingManager implements ChattingManager {
         }
 
         db.orderByChild(DB_USER + "/" + uuid)
+                .equalTo(true)
                 .addListenerForSingleValueEvent(new ValueEventListener() {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot dataSnapshot) {

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/remote/RemoteChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/remote/RemoteChattingManager.java
@@ -40,7 +40,11 @@ public class RemoteChattingManager implements ChattingManager {
     }
 
     @Override
-    public void getChattingRoom(@NonNull String uuid, @NonNull String destinationUuid, @NonNull OnSuccessListener<String> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void getChattingRoom(@NonNull String uuid,
+                                @NonNull String destinationUuid,
+                                @NonNull OnSuccessListener<String> onSuccessListener,
+                                @NonNull OnFailureListener onFailureListener) {
+
         if (FirebaseAuth.getInstance().getCurrentUser() == null) {
             onFailureListener.onFailure(new RuntimeException(NOT_SIGNED_USER));
             return;
@@ -80,6 +84,7 @@ public class RemoteChattingManager implements ChattingManager {
         }
 
         db.orderByChild(DB_USER + "/" + uuid)
+                .equalTo(true)
                 .addListenerForSingleValueEvent(new ValueEventListener() {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot dataSnapshot) {

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/APIManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/APIManager.java
@@ -8,6 +8,7 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.AuthResult;
+import com.swsnack.catchhouse.data.userdata.pojo.User;
 
 public interface APIManager {
 
@@ -18,7 +19,7 @@ public interface APIManager {
 
     void signUp(@NonNull String email, @NonNull String password, @NonNull OnSuccessListener<AuthResult> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
-    void getUserInfoFromFacebook(@NonNull AccessToken accessToken, GraphRequest.GraphJSONObjectCallback facebookUserDataCallback);
+    void getUserInfoFromFacebook(@NonNull AccessToken accessToken, @NonNull OnSuccessListener<User> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
     void signIn(@NonNull String email, @NonNull String password, @NonNull OnSuccessListener<AuthResult> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/UserDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/UserDataManager.java
@@ -3,12 +3,9 @@ package com.swsnack.catchhouse.data.userdata;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
-import com.bumptech.glide.request.RequestListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.firebase.database.ValueEventListener;
 import com.swsnack.catchhouse.data.userdata.pojo.User;
 
 import java.util.Map;
@@ -23,7 +20,7 @@ public interface UserDataManager {
                                    @NonNull OnSuccessListener<User> onSuccessListener,
                                    @NonNull OnFailureListener onFailureListener);
 
-    void setUser(@NonNull String uuid, @NonNull User user, @Nullable OnSuccessListener<Void> onSuccessListener, @Nullable OnFailureListener onFailureListener);
+    void setUser(@NonNull String uuid, @NonNull User user, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
     void updateUser(@NonNull String uuid, @NonNull Map<String, Object> updateFields, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
@@ -33,12 +30,15 @@ public interface UserDataManager {
 
     void uploadProfile(@NonNull String uuid, @NonNull Uri imageUri, @NonNull OnSuccessListener<Uri> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
-    void getProfile(@NonNull Uri uri, RequestListener<Bitmap> requestListener);
+    void getProfile(@NonNull Uri uri, @NonNull OnSuccessListener<Bitmap> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
     void updateProfile(@NonNull String uuid, @NonNull Uri uri, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
     void deleteProfile(@NonNull String uuid, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
-    void findUserByQueryString(@NonNull String queryString, @NonNull String findValue, @NonNull ValueEventListener valueEventListener);
+    void findUserByQueryString(@NonNull String queryString,
+                               @NonNull String findValue,
+                               @NonNull OnSuccessListener<String> onSuccessListener,
+                               @NonNull OnFailureListener onFailureListener);
 
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/api/AppAPIManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/api/AppAPIManager.java
@@ -2,7 +2,6 @@ package com.swsnack.catchhouse.data.userdata.api;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.util.Log;
 
 import com.facebook.AccessToken;
 import com.facebook.GraphRequest;
@@ -15,8 +14,11 @@ import com.google.firebase.auth.EmailAuthProvider;
 import com.google.firebase.auth.FirebaseAuth;
 import com.swsnack.catchhouse.constants.Constants;
 import com.swsnack.catchhouse.data.userdata.APIManager;
+import com.swsnack.catchhouse.data.userdata.pojo.User;
 
 import static com.swsnack.catchhouse.constants.Constants.ExceptionReason.NOT_SIGNED_USER;
+import static com.swsnack.catchhouse.constants.Constants.FacebookData.GENDER;
+import static com.swsnack.catchhouse.constants.Constants.FacebookData.NAME;
 
 public class AppAPIManager implements APIManager {
 
@@ -40,7 +42,11 @@ public class AppAPIManager implements APIManager {
     }
 
     @Override
-    public void signUp(@NonNull String email, @NonNull String password, @NonNull OnSuccessListener<AuthResult> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void signUp(@NonNull String email,
+                       @NonNull String password,
+                       @NonNull OnSuccessListener<AuthResult> onSuccessListener,
+                       @NonNull OnFailureListener onFailureListener) {
+
         FirebaseAuth.getInstance()
                 .createUserWithEmailAndPassword(email, password)
                 .addOnSuccessListener(onSuccessListener)
@@ -48,8 +54,16 @@ public class AppAPIManager implements APIManager {
     }
 
     @Override
-    public void getUserInfoFromFacebook(@NonNull AccessToken token, GraphRequest.GraphJSONObjectCallback facebookUserDataCallback) {
-        GraphRequest request = GraphRequest.newMeRequest(token, facebookUserDataCallback);
+    public void getUserInfoFromFacebook(@NonNull AccessToken token, @NonNull OnSuccessListener<User> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+        GraphRequest request = GraphRequest
+                .newMeRequest(token,
+                        (result, response) -> {
+                            if (result == null) {
+                                onFailureListener.onFailure(new RuntimeException());
+                                return;
+                            }
+                            onSuccessListener.onSuccess(new User(result.optString(NAME), result.optString(GENDER)));
+                        });
         Bundle parameter = new Bundle();
         parameter.putString(Constants.FacebookData.KEY, Constants.FacebookData.VALUE);
         request.setParameters(parameter);
@@ -57,7 +71,11 @@ public class AppAPIManager implements APIManager {
     }
 
     @Override
-    public void signIn(@NonNull String email, @NonNull String password, @NonNull OnSuccessListener<AuthResult> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void signIn(@NonNull String email,
+                       @NonNull String password,
+                       @NonNull OnSuccessListener<AuthResult> onSuccessListener,
+                       @NonNull OnFailureListener onFailureListener) {
+
         FirebaseAuth.getInstance()
                 .signInWithEmailAndPassword(email, password)
                 .addOnSuccessListener(onSuccessListener)
@@ -80,7 +98,11 @@ public class AppAPIManager implements APIManager {
     }
 
     @Override
-    public void updatePassword(@NonNull String oldPassword, @NonNull String newPassword, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void updatePassword(@NonNull String oldPassword,
+                               @NonNull String newPassword,
+                               @NonNull OnSuccessListener<Void> onSuccessListener,
+                               @NonNull OnFailureListener onFailureListener) {
+
         if (FirebaseAuth.getInstance().getCurrentUser() == null) {
             onFailureListener.onFailure(new FirebaseException(NOT_SIGNED_USER));
             return;

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/remote/AppUserDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/remote/AppUserDataManager.java
@@ -87,6 +87,7 @@ public class AppUserDataManager implements UserDataManager {
     public void getUserFromSingleSnapShot(@NonNull String uuid,
                                           @NonNull OnSuccessListener<User> onSuccessListener,
                                           @NonNull OnFailureListener onFailureListener) {
+
         db.child(uuid).addListenerForSingleValueEvent(new ValueEventListener() {
             @Override
             public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
@@ -106,7 +107,11 @@ public class AppUserDataManager implements UserDataManager {
     }
 
     @Override
-    public void uploadProfile(@NonNull String uuid, @NonNull Uri imageUri, @NonNull OnSuccessListener<Uri> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void uploadProfile(@NonNull String uuid,
+                              @NonNull Uri imageUri,
+                              @NonNull OnSuccessListener<Uri> onSuccessListener,
+                              @NonNull OnFailureListener onFailureListener) {
+
         StorageReference reference = fs.child(uuid);
         getProfile(imageUri,
                 bitmap -> {
@@ -156,7 +161,8 @@ public class AppUserDataManager implements UserDataManager {
                             setUser(uuid, user,
                                     onSuccessListener,
                                     onFailureListener);
-                        }, onFailureListener),
+                        },
+                        onFailureListener),
                 onFailureListener);
     }
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/remote/AppUserDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/remote/AppUserDataManager.java
@@ -100,7 +100,7 @@ public class AppUserDataManager implements UserDataManager {
 
             @Override
             public void onCancelled(@NonNull DatabaseError databaseError) {
-
+                onFailureListener.onFailure(databaseError.toException());
             }
         });
     }

--- a/app/src/main/java/com/swsnack/catchhouse/view/activities/BottomNavActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activities/BottomNavActivity.java
@@ -3,6 +3,7 @@ package com.swsnack.catchhouse.view.activities;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.view.ViewPager;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
@@ -43,6 +44,7 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
 
     private FragmentManager mFragmentManager;
     private CompositeDisposable mDisposable;
+    private OnViewPagerChangedListener mViewPagerListener;
 
     @Override
     protected int getLayout() {
@@ -162,6 +164,36 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
         list.add(new SignFragment());
 
         getBinding().vpBottomNav.setAdapter(viewPagerAdapter);
+        getBinding().vpBottomNav.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int i, float v, int i1) {
+
+            }
+
+            @Override
+            public void onPageSelected(int i) {
+                switch (i) {
+                    case 0:
+                        getBinding().bottomNav.setSelectedItemId(R.id.action_home);
+                        break;
+                    case 1:
+                        getBinding().bottomNav.setSelectedItemId(R.id.action_map);
+                        break;
+                    case 2:
+                        getBinding().bottomNav.setSelectedItemId(R.id.action_message);
+                        mViewPagerListener.onViewPagerChanged();
+                        break;
+                    case 3:
+                        getBinding().bottomNav.setSelectedItemId(R.id.action_my_page);
+                        break;
+                }
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int i) {
+
+            }
+        });
         viewPagerAdapter.setItems(list);
     }
 
@@ -180,5 +212,9 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
     @Override
     public void onClicked() {
         getBinding().bottomNav.setSelectedItemId(R.id.action_map);
+    }
+
+    public void setViewPagerListener(OnViewPagerChangedListener onViewPagerChangedListener) {
+        this.mViewPagerListener = onViewPagerChangedListener;
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/view/activities/OnViewPagerChangedListener.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activities/OnViewPagerChangedListener.java
@@ -1,0 +1,5 @@
+package com.swsnack.catchhouse.view.activities;
+
+public interface OnViewPagerChangedListener {
+    void onViewPagerChanged();
+}

--- a/app/src/main/java/com/swsnack/catchhouse/view/fragments/ChatListFragment.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/fragments/ChatListFragment.java
@@ -1,5 +1,6 @@
 package com.swsnack.catchhouse.view.fragments;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -14,7 +15,11 @@ import com.swsnack.catchhouse.R;
 import com.swsnack.catchhouse.adapters.chattingadapter.ChattingListAdapter;
 import com.swsnack.catchhouse.databinding.FragmentChatListBinding;
 import com.swsnack.catchhouse.view.BaseFragment;
+import com.swsnack.catchhouse.view.activities.BottomNavActivity;
 import com.swsnack.catchhouse.viewmodel.chattingviewmodel.ChattingViewModel;
+
+import java.util.ArrayList;
+import java.util.Objects;
 
 public class ChatListFragment extends BaseFragment<FragmentChatListBinding, ChattingViewModel> {
 
@@ -26,6 +31,14 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
     @Override
     protected Class<ChattingViewModel> getViewModelClass() {
         return ChattingViewModel.class;
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if(context instanceof BottomNavActivity) {
+            ((BottomNavActivity) Objects.requireNonNull(getActivity())).setViewPagerListener(this::getChattingList);
+        }
     }
 
     @Override
@@ -53,20 +66,16 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
 
     }
 
-    @Override
-    public void onResume() {
-        super.onResume();
+    public void getChattingList() {
         if (FirebaseAuth.getInstance().getCurrentUser() == null) {
             getBinding().tvChatListNotSigned.setVisibility(View.VISIBLE);
+        } else {
+            getBinding().tvChatListNotSigned.setVisibility(View.GONE);
         }
         /* set dummy data*/
-        getViewModel().getList();
+        getViewModel().setChattingList(new ArrayList<>());
+        getViewModel().getChattingRoomList();
         getViewModel().setChattingList();
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
     }
 
 }

--- a/app/src/main/java/com/swsnack/catchhouse/view/fragments/ChatListFragment.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/fragments/ChatListFragment.java
@@ -61,6 +61,7 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
         }
         /* set dummy data*/
         getViewModel().getList();
+        getViewModel().setChattingList();
     }
 
     @Override

--- a/app/src/main/java/com/swsnack/catchhouse/view/fragments/ChatListFragment.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/fragments/ChatListFragment.java
@@ -69,13 +69,13 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
     public void getChattingList() {
         if (FirebaseAuth.getInstance().getCurrentUser() == null) {
             getBinding().tvChatListNotSigned.setVisibility(View.VISIBLE);
+            getViewModel().setChattingList(new ArrayList<>());
         } else {
             getBinding().tvChatListNotSigned.setVisibility(View.GONE);
+            /* set dummy data*/
+            getViewModel().getChattingRoomList();
+            getViewModel().setChattingRoom();
         }
-        /* set dummy data*/
-        getViewModel().setChattingList(new ArrayList<>());
-        getViewModel().getChattingRoomList();
-        getViewModel().setChattingList();
     }
 
 }

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
@@ -53,7 +53,7 @@ public class ChattingViewModel extends ReactiveViewModel {
 
         /* dummy data for testing*/
         users.put(FirebaseAuth.getInstance().getCurrentUser().getUid(), true);
-        users.put("BkhNTh50J1diyDPj14HSpRhlxBH3", true);
+        users.put("RvXHEN2wXAMDQRvjQkgrfL0rWOC3", true);
 
         Chatting chatting = new Chatting(users);
         getDataManager()
@@ -68,7 +68,7 @@ public class ChattingViewModel extends ReactiveViewModel {
             if (!uuid.equals(FirebaseAuth.getInstance().getCurrentUser().toString())) {
                 getDataManager()
                         .getUserFromSingleSnapShot(uuid,
-                                onSuccessListener::onSuccess,
+                                onSuccessListener,
                                 onFailureListener);
                 return;
             }

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
@@ -44,7 +44,7 @@ public class ChattingViewModel extends ReactiveViewModel {
                         error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_database_exception)));
     }
 
-    public void setChattingList() {
+    public void setChattingRoom() {
         Map<String, Boolean> users = new HashMap<>();
         if (FirebaseAuth.getInstance().getCurrentUser() == null) {
             return;

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
@@ -33,15 +33,15 @@ public class ChattingViewModel extends ReactiveViewModel {
         this.mChattingList = new MutableLiveData<>();
     }
 
-    public void getList() {
+    public void getChattingRoomList() {
         if (FirebaseAuth.getInstance().getCurrentUser() == null) {
-            mListener.onError(StringUtil.getStringFromResource(R.string.snack_fb_not_signed_user));
             return;
         }
 
-        getDataManager().getChattingList(FirebaseAuth.getInstance().getCurrentUser().getUid(),
-                list -> mChattingList.setValue(list),
-                error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_database_exception)));
+        getDataManager()
+                .getChattingList(FirebaseAuth.getInstance().getCurrentUser().getUid(),
+                        list -> mChattingList.setValue(list),
+                        error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_database_exception)));
     }
 
     public void setChattingList() {
@@ -76,7 +76,11 @@ public class ChattingViewModel extends ReactiveViewModel {
 
     }
 
-    public LiveData<List<Chatting>> chattingList() {
+    public LiveData<List<Chatting>> getChattingList() {
         return this.mChattingList;
+    }
+
+    public void setChattingList(List<Chatting> list) {
+        this.mChattingList.setValue(list);
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/userviewmodel/UserViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/userviewmodel/UserViewModel.java
@@ -119,15 +119,11 @@ public class UserViewModel extends ReactiveViewModel {
         mListener.isWorking();
         getDataManager()
                 .getUserInfoFromFacebook(loginResult.getAccessToken(),
-                        (result, response) -> {
-                            if (result == null) {
-                                mListener.onError(getStringFromResource(R.string.snack_not_found_info));
-                                return;
-                            }
-                            User user = new User(result.optString(NAME), result.optString(GENDER));
+                        user -> {
                             user.setProfile(uri.toString());
                             signUpWithCredential(FacebookAuthProvider.getCredential(loginResult.getAccessToken().getToken()), user);
-                        });
+                        },
+                        error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_not_found_info)));
     }
 
     private void signUpWithCredential(AuthCredential authCredential, User user) {

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/userviewmodel/UserViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/userviewmodel/UserViewModel.java
@@ -7,13 +7,8 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.View;
 
-import com.bumptech.glide.load.DataSource;
-import com.bumptech.glide.load.engine.GlideException;
-import com.bumptech.glide.request.RequestListener;
-import com.bumptech.glide.request.target.Target;
 import com.facebook.login.LoginResult;
 import com.google.android.gms.auth.api.signin.GoogleSignIn;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
@@ -25,12 +20,10 @@ import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
 import com.google.firebase.auth.FirebaseAuthInvalidUserException;
 import com.google.firebase.auth.FirebaseAuthUserCollisionException;
 import com.google.firebase.auth.GoogleAuthProvider;
-import com.google.firebase.database.DataSnapshot;
-import com.google.firebase.database.DatabaseError;
-import com.google.firebase.database.ValueEventListener;
 import com.swsnack.catchhouse.R;
 import com.swsnack.catchhouse.data.DataManager;
 import com.swsnack.catchhouse.data.userdata.pojo.User;
+import com.swsnack.catchhouse.util.StringUtil;
 import com.swsnack.catchhouse.viewmodel.ReactiveViewModel;
 import com.swsnack.catchhouse.viewmodel.ViewModelListener;
 
@@ -84,20 +77,12 @@ public class UserViewModel extends ReactiveViewModel {
         mListener.isWorking();
         mProfileUri = uri;
         getDataManager()
-                .getProfile(uri, new RequestListener<Bitmap>() {
-                    @Override
-                    public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Bitmap> target, boolean isFirstResource) {
-                        mListener.onError(getStringFromResource(R.string.snack_failed_load_image));
-                        return false;
-                    }
-
-                    @Override
-                    public boolean onResourceReady(Bitmap resource, Object model, Target<Bitmap> target, DataSource dataSource, boolean isFirstResource) {
-                        mListener.isFinished();
-                        mProfile.setValue(resource);
-                        return true;
-                    }
-                });
+                .getProfile(uri,
+                        bitmap -> {
+                            mListener.isFinished();
+                            mProfile.setValue(bitmap);
+                        },
+                        error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_failed_load_image)));
     }
 
     public void getUser() {


### PR DESCRIPTION
## 개요
- ChattingListFragment에서 나타나던 오류 수정
- 콜백 구조의 Model 함수 리팩토링


## 구현사항
- ChattingListFragment에서 Fragment 전환 후, 다시 ChattingList로 돌아올때, 채팅 리스트 갱신 기능 추가
- BottomNavActivity에서, 뷰페이저 이동시 하단 네비게이션 버튼이 변화되지 않던 버그 수정
- ViewPager의 Fragment 전환시, ChattingListFragment의 로그인 정보 확인 후 채팅 리스트 갱신

## 리뷰 요청사항
- 


resolve: #48 
