### PR TITLE
데이터 매니저 분리 및 위치정보를 DB 올리는 기능

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     implementation "com.google.android.gms:play-services-auth:$rootProject.ext.googleAuthVersion"
     //firebase facebook auth api
     implementation "com.facebook.android:facebook-login:$rootProject.ext.facebookAuthVersion"
+    //firebase geofire
+    implementation "com.firebase:geofire-android:$rootProject.ext.geofireVersion"
     //glide
     implementation "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
     annotationProcessor "com.github.bumptech.glide:compiler:$rootProject.ext.glideVersion"

--- a/app/src/main/java/com/swsnack/catchhouse/Constant.java
+++ b/app/src/main/java/com/swsnack/catchhouse/Constant.java
@@ -24,6 +24,8 @@ import static com.swsnack.catchhouse.Constant.FacebookData.KEY;
 import static com.swsnack.catchhouse.Constant.FacebookData.NAME;
 import static com.swsnack.catchhouse.Constant.FacebookData.VALUE;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.CHATTING;
+import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_LOCATION;
+import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_ROOM;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_USER;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.NICK_NAME;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_PROFILE;
@@ -87,10 +89,11 @@ public class Constant {
     }
 
     @Retention(RetentionPolicy.SOURCE)
-    @StringDef({DB_USER, STORAGE_PROFILE, STORAGE_ROOM_IMAGE, NICK_NAME, CHATTING})
+    @StringDef({DB_USER, DB_ROOM, DB_LOCATION, STORAGE_PROFILE, STORAGE_ROOM_IMAGE, NICK_NAME, CHATTING})
     public @interface FirebaseKey {
         String DB_USER = "users";
         String DB_ROOM = "rooms";
+        String DB_LOCATION = "location";
         String STORAGE_PROFILE = "profile";
         String STORAGE_ROOM_IMAGE = "roomImage";
         String NICK_NAME = "nickName";

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -16,6 +16,7 @@ import com.google.firebase.database.ValueEventListener;
 import com.swsnack.catchhouse.data.chattingdata.ChattingManager;
 import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.data.chattingdata.model.Message;
+import com.swsnack.catchhouse.data.roomdata.RoomDataManager;
 import com.swsnack.catchhouse.data.roomsdata.pojo.Room;
 import com.swsnack.catchhouse.data.userdata.APIManager;
 import com.swsnack.catchhouse.data.userdata.UserDataManager;
@@ -31,20 +32,26 @@ public class AppDataManager implements DataManager {
     private APIManager mApiManager;
     private UserDataManager mUserDataManager;
     private ChattingManager mRemoteChattingManager;
+    private RoomDataManager mRoomDataManager;
 
-    private AppDataManager(APIManager apiManager, UserDataManager userDataManager, ChattingManager remoteChattingManager) {
+    private AppDataManager(APIManager apiManager,
+                           UserDataManager userDataManager,
+                           ChattingManager remoteChattingManager,
+                           RoomDataManager roomDataManager) {
         mApiManager = apiManager;
         mUserDataManager = userDataManager;
         mRemoteChattingManager = remoteChattingManager;
+        mRoomDataManager = roomDataManager;
     }
 
     private static AppDataManager INSTANCE;
 
     public static synchronized AppDataManager getInstance(@NonNull APIManager apiManager,
                                                           @NonNull UserDataManager userDataManager,
-                                                          @NonNull ChattingManager remoteChattingManager) {
+                                                          @NonNull ChattingManager remoteChattingManager,
+                                                          @NonNull RoomDataManager roomDataManager) {
         if (INSTANCE == null) {
-            INSTANCE = new AppDataManager(apiManager, userDataManager, remoteChattingManager);
+            INSTANCE = new AppDataManager(apiManager, userDataManager, remoteChattingManager, roomDataManager);
         }
         return INSTANCE;
     }
@@ -119,8 +126,10 @@ public class AppDataManager implements DataManager {
                                                 error -> {
                                                     onFailureListener.onFailure(error);
                                                     setUser(uuid, user,
-                                                            Void -> {},
-                                                            transactionError -> {});
+                                                            Void -> {
+                                                            },
+                                                            transactionError -> {
+                                                            });
                                                 });
                                         return;
                                     }
@@ -130,8 +139,10 @@ public class AppDataManager implements DataManager {
                                             error -> {
                                                 onFailureListener.onFailure(error);
                                                 setUser(uuid, user,
-                                                        Void -> {},
-                                                        transactionError -> {});
+                                                        Void -> {
+                                                        },
+                                                        transactionError -> {
+                                                        });
                                             });
                                 },
                                 onFailureListener),
@@ -259,20 +270,20 @@ public class AppDataManager implements DataManager {
     @Override
     public void createKey(@NonNull OnSuccessListener<String> onSuccessListener,
                           @NonNull OnFailureListener onFailureListener) {
-        mUserDataManager.createKey(onSuccessListener, onFailureListener);
+        mRoomDataManager.createKey(onSuccessListener, onFailureListener);
     }
 
     @Override
     public void uploadRoomImage(@NonNull String uuid, @NonNull List<byte[]> imageList,
                                 @NonNull OnSuccessListener<List<String>> onSuccessListener,
                                 @NonNull OnFailureListener onFailureListener) {
-        mUserDataManager.uploadRoomImage(uuid, imageList, onSuccessListener, onFailureListener);
+        mRoomDataManager.uploadRoomImage(uuid, imageList, onSuccessListener, onFailureListener);
     }
 
     @Override
     public void uploadRoomData(@NonNull String uuid, @NonNull Room room,
                                @NonNull OnSuccessListener<Void> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
-        mUserDataManager.uploadRoomData(uuid, room, onSuccessListener, onFailureListener);
+        mRoomDataManager.uploadRoomData(uuid, room, onSuccessListener, onFailureListener);
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -16,7 +16,9 @@ import com.google.firebase.database.ValueEventListener;
 import com.swsnack.catchhouse.data.chattingdata.ChattingManager;
 import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.data.chattingdata.model.Message;
+import com.swsnack.catchhouse.data.locationdata.LocationDataManager;
 import com.swsnack.catchhouse.data.roomdata.RoomDataManager;
+import com.swsnack.catchhouse.data.roomsdata.pojo.Address;
 import com.swsnack.catchhouse.data.roomsdata.pojo.Room;
 import com.swsnack.catchhouse.data.userdata.APIManager;
 import com.swsnack.catchhouse.data.userdata.UserDataManager;
@@ -33,15 +35,18 @@ public class AppDataManager implements DataManager {
     private UserDataManager mUserDataManager;
     private ChattingManager mRemoteChattingManager;
     private RoomDataManager mRoomDataManager;
+    private LocationDataManager mLocationDataManager;
 
     private AppDataManager(APIManager apiManager,
                            UserDataManager userDataManager,
                            ChattingManager remoteChattingManager,
-                           RoomDataManager roomDataManager) {
+                           RoomDataManager roomDataManager,
+                           LocationDataManager locationDataManager) {
         mApiManager = apiManager;
         mUserDataManager = userDataManager;
         mRemoteChattingManager = remoteChattingManager;
         mRoomDataManager = roomDataManager;
+        mLocationDataManager = locationDataManager;
     }
 
     private static AppDataManager INSTANCE;
@@ -49,9 +54,14 @@ public class AppDataManager implements DataManager {
     public static synchronized AppDataManager getInstance(@NonNull APIManager apiManager,
                                                           @NonNull UserDataManager userDataManager,
                                                           @NonNull ChattingManager remoteChattingManager,
-                                                          @NonNull RoomDataManager roomDataManager) {
+                                                          @NonNull RoomDataManager roomDataManager,
+                                                          @NonNull LocationDataManager locationDataManager) {
         if (INSTANCE == null) {
-            INSTANCE = new AppDataManager(apiManager, userDataManager, remoteChattingManager, roomDataManager);
+            INSTANCE = new AppDataManager(apiManager,
+                    userDataManager,
+                    remoteChattingManager,
+                    roomDataManager,
+                    locationDataManager);
         }
         return INSTANCE;
     }
@@ -285,5 +295,12 @@ public class AppDataManager implements DataManager {
                                @NonNull OnSuccessListener<Void> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
         mRoomDataManager.uploadRoomData(uuid, room, onSuccessListener, onFailureListener);
+    }
+
+    @Override
+    public void uploadLocationData(@NonNull String uuid, @NonNull Address address,
+                                   @NonNull OnSuccessListener<String> onSuccessListener,
+                                   @NonNull OnFailureListener onFailureListener) {
+        mLocationDataManager.uploadLocationData(uuid, address, onSuccessListener, onFailureListener);
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/DataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/DataManager.java
@@ -8,11 +8,12 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.auth.AuthCredential;
 import com.swsnack.catchhouse.data.chattingdata.ChattingManager;
+import com.swsnack.catchhouse.data.roomdata.RoomDataManager;
 import com.swsnack.catchhouse.data.userdata.APIManager;
 import com.swsnack.catchhouse.data.userdata.UserDataManager;
 import com.swsnack.catchhouse.data.userdata.model.User;
 
-public interface DataManager extends APIManager, UserDataManager, ChattingManager {
+public interface DataManager extends APIManager, UserDataManager, ChattingManager, RoomDataManager {
 
     APIManager getAPIManager();
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/DataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/DataManager.java
@@ -8,12 +8,13 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.auth.AuthCredential;
 import com.swsnack.catchhouse.data.chattingdata.ChattingManager;
+import com.swsnack.catchhouse.data.locationdata.LocationDataManager;
 import com.swsnack.catchhouse.data.roomdata.RoomDataManager;
 import com.swsnack.catchhouse.data.userdata.APIManager;
 import com.swsnack.catchhouse.data.userdata.UserDataManager;
 import com.swsnack.catchhouse.data.userdata.model.User;
 
-public interface DataManager extends APIManager, UserDataManager, ChattingManager, RoomDataManager {
+public interface DataManager extends APIManager, UserDataManager, ChattingManager, RoomDataManager, LocationDataManager {
 
     APIManager getAPIManager();
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/locationdata/LocationDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/locationdata/LocationDataManager.java
@@ -1,0 +1,14 @@
+package com.swsnack.catchhouse.data.locationdata;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.swsnack.catchhouse.data.roomsdata.pojo.Address;
+
+public interface LocationDataManager {
+
+    void uploadLocationData(@NonNull String uuid, @NonNull Address address,
+                            @NonNull OnSuccessListener<String> onSuccessListener,
+                            @NonNull OnFailureListener onFailureListener);
+}

--- a/app/src/main/java/com/swsnack/catchhouse/data/locationdata/remote/AppLocationDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/locationdata/remote/AppLocationDataManager.java
@@ -1,0 +1,49 @@
+package com.swsnack.catchhouse.data.locationdata.remote;
+
+import android.support.annotation.NonNull;
+
+import com.firebase.geofire.GeoFire;
+import com.firebase.geofire.GeoLocation;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.database.FirebaseDatabase;
+import com.swsnack.catchhouse.data.locationdata.LocationDataManager;
+import com.swsnack.catchhouse.data.roomsdata.pojo.Address;
+
+import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_LOCATION;
+
+public class AppLocationDataManager implements LocationDataManager {
+
+    private GeoFire gf;
+
+    private static AppLocationDataManager INSTANCE;
+
+    public static synchronized AppLocationDataManager getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new AppLocationDataManager();
+        }
+        return INSTANCE;
+    }
+
+    private AppLocationDataManager() {
+        gf = new GeoFire(FirebaseDatabase.getInstance().getReference().child(DB_LOCATION));
+    }
+
+    @Override
+    public void uploadLocationData(@NonNull String uuid, @NonNull Address address,
+                                   @NonNull OnSuccessListener<String> onSuccessListener,
+                                   @NonNull OnFailureListener onFailureListener) {
+
+        GeoLocation geoLocation = new GeoLocation(address.getLatitude(), address.getLongitude());
+
+        gf.setLocation(uuid, geoLocation, (key, error) -> {
+                    if (error == null) {
+                        onSuccessListener.onSuccess(key);
+                    } else {
+                        onFailureListener.onFailure(new RuntimeException("error"));
+                    }
+                }
+        );
+
+    }
+}

--- a/app/src/main/java/com/swsnack/catchhouse/data/roomdata/RoomDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/roomdata/RoomDataManager.java
@@ -1,0 +1,24 @@
+package com.swsnack.catchhouse.data.roomdata;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.swsnack.catchhouse.data.roomsdata.pojo.Room;
+
+import java.util.List;
+
+public interface RoomDataManager {
+
+    void createKey(@NonNull OnSuccessListener<String> onSuccessListener,
+                   @NonNull OnFailureListener onFailureListener);
+
+    void uploadRoomImage(@NonNull String uuid, @NonNull List<byte[]> imageList,
+                         @NonNull OnSuccessListener<List<String>> onSuccessListener,
+                         @NonNull OnFailureListener onFailureListener);
+
+    void uploadRoomData(@NonNull String uuid, @NonNull Room room,
+                        @NonNull OnSuccessListener<Void> onSuccessListener,
+                        @NonNull OnFailureListener onFailureListener);
+
+}

--- a/app/src/main/java/com/swsnack/catchhouse/data/roomdata/remote/AppRoomDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/roomdata/remote/AppRoomDataManager.java
@@ -21,6 +21,7 @@ import com.swsnack.catchhouse.data.roomsdata.pojo.Room;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_ROOM;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_ROOM_IMAGE;
 import static com.swsnack.catchhouse.Constant.PostException.NETWORK_ERROR;
 
@@ -39,7 +40,7 @@ public class AppRoomDataManager implements RoomDataManager {
     }
 
     private AppRoomDataManager() {
-        db = FirebaseDatabase.getInstance().getReference().child("rooms");
+        db = FirebaseDatabase.getInstance().getReference().child(DB_ROOM);
         fs = FirebaseStorage.getInstance().getReference().child(STORAGE_ROOM_IMAGE);
     }
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/roomdata/remote/AppRoomDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/roomdata/remote/AppRoomDataManager.java
@@ -1,0 +1,117 @@
+package com.swsnack.catchhouse.data.roomdata.remote;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+
+import com.google.android.gms.tasks.Continuation;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+import com.google.firebase.storage.UploadTask;
+import com.swsnack.catchhouse.data.roomdata.RoomDataManager;
+import com.swsnack.catchhouse.data.roomsdata.pojo.Room;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_ROOM_IMAGE;
+import static com.swsnack.catchhouse.Constant.PostException.NETWORK_ERROR;
+
+public class AppRoomDataManager implements RoomDataManager {
+
+    private DatabaseReference db;
+    private StorageReference fs;
+
+    private static AppRoomDataManager INSTANCE;
+
+    public static synchronized AppRoomDataManager getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new AppRoomDataManager();
+        }
+        return INSTANCE;
+    }
+
+    private AppRoomDataManager() {
+        db = FirebaseDatabase.getInstance().getReference().child("rooms");
+        fs = FirebaseStorage.getInstance().getReference().child(STORAGE_ROOM_IMAGE);
+    }
+
+    @Override
+    public void createKey(@NonNull OnSuccessListener<String> onSuccessListener,
+                          @NonNull OnFailureListener onFailureListener) {
+        db.push().addListenerForSingleValueEvent(new ValueEventListener() {
+            @Override
+            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
+                String key = dataSnapshot.getKey();
+                if (key != null) {
+                    onSuccessListener.onSuccess(key);
+                } else {
+                    onFailureListener.onFailure(new RuntimeException(NETWORK_ERROR));
+                }
+            }
+
+            @Override
+            public void onCancelled(@NonNull DatabaseError databaseError) {
+                onFailureListener.onFailure(new RuntimeException(NETWORK_ERROR));
+            }
+        });
+    }
+
+    @Override
+    public void uploadRoomImage(@NonNull String uuid, @NonNull List<byte[]> imageList,
+                                @NonNull OnSuccessListener<List<String>> onSuccessListener,
+                                @NonNull OnFailureListener onFailureListener) {
+
+        List<String> list = new ArrayList<>();
+        List<StorageReference> innerRef = new ArrayList<>();
+        for (int i = 0; i < imageList.size(); i++) {
+            innerRef.add(fs.child(uuid + "/" + i));
+        }
+        UploadTask uploadTask = innerRef.get(0).putBytes(imageList.remove(0));
+
+        Continuation<UploadTask.TaskSnapshot, Task<Uri>> continuation = task -> {
+            if (!task.isSuccessful()) {
+                onFailureListener.onFailure(new RuntimeException(NETWORK_ERROR));
+            }
+            return innerRef.remove(0).getDownloadUrl();
+        };
+
+
+        OnSuccessListener<Uri> loopListener = new OnSuccessListener<Uri>() {
+            @Override
+            public void onSuccess(Uri uri) {
+                list.add(uri.toString());
+
+                if (!imageList.isEmpty()) {
+                    innerRef.get(0).putBytes(imageList.remove(0))
+                            .continueWithTask(continuation)
+                            .addOnSuccessListener(this)
+                            .addOnFailureListener(onFailureListener);
+                } else {
+                    onSuccessListener.onSuccess(list);
+                }
+            }
+        };
+
+        uploadTask
+                .continueWithTask(continuation)
+                .addOnSuccessListener(loopListener)
+                .addOnFailureListener(onFailureListener);
+    }
+
+    @Override
+    public void uploadRoomData(@NonNull String uuid, @NonNull Room room,
+                               @NonNull OnSuccessListener<Void> onSuccessListener,
+                               @NonNull OnFailureListener onFailureListener) {
+        db.child(uuid).setValue(room)
+                .addOnSuccessListener(onSuccessListener)
+                .addOnFailureListener(onFailureListener);
+    }
+}

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/UserDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/UserDataManager.java
@@ -6,10 +6,8 @@ import android.support.annotation.NonNull;
 
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
-import com.swsnack.catchhouse.data.roomsdata.pojo.Room;
 import com.swsnack.catchhouse.data.userdata.model.User;
 
-import java.util.List;
 import java.util.Map;
 
 public interface UserDataManager {
@@ -37,12 +35,6 @@ public interface UserDataManager {
     void updateProfile(@NonNull String uuid, @NonNull Uri uri, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
     void deleteProfile(@NonNull String uuid, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
-
-    void createKey(@NonNull OnSuccessListener<String> onSuccessListener, @NonNull OnFailureListener onFailureListener);
-
-    void uploadRoomImage(@NonNull String uuid, @NonNull List<byte[]> imageList, @NonNull OnSuccessListener<List<String>> onSuccessListener, @NonNull OnFailureListener onFailureListener);
-
-    void uploadRoomData(@NonNull String uuid, @NonNull Room room, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
     void findUserByQueryString(@NonNull String queryString,
                                @NonNull String findValue,

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/remote/AppUserDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/remote/AppUserDataManager.java
@@ -11,10 +11,8 @@ import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
-import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.android.gms.tasks.Task;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseException;
@@ -25,34 +23,26 @@ import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
 import com.swsnack.catchhouse.AppApplication;
-import com.swsnack.catchhouse.data.roomsdata.pojo.Room;
 import com.swsnack.catchhouse.data.userdata.UserDataManager;
 import com.swsnack.catchhouse.data.userdata.model.User;
 import com.swsnack.catchhouse.util.DataConverter;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static com.swsnack.catchhouse.Constant.ExceptionReason.DUPLICATE;
 import static com.swsnack.catchhouse.Constant.ExceptionReason.DUPLICATE_NICK_NAME;
 import static com.swsnack.catchhouse.Constant.ExceptionReason.FAILED_UPDATE;
 import static com.swsnack.catchhouse.Constant.ExceptionReason.NOT_SIGNED_USER;
-import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_ROOM;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_USER;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.NICK_NAME;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_PROFILE;
-import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_ROOM_IMAGE;
-import static com.swsnack.catchhouse.Constant.PostException.NETWORK_ERROR;
 
 public class AppUserDataManager implements UserDataManager {
 
     private DatabaseReference db;
-    private DatabaseReference dbRooms;
     private StorageReference fs;
-    private StorageReference fsRooms;
     private Application mAppContext;
 
     private static AppUserDataManager INSTANCE;
@@ -66,9 +56,7 @@ public class AppUserDataManager implements UserDataManager {
 
     private AppUserDataManager() {
         db = FirebaseDatabase.getInstance().getReference().child(DB_USER);
-        dbRooms = FirebaseDatabase.getInstance().getReference().child(DB_ROOM);
         fs = FirebaseStorage.getInstance().getReference().child(STORAGE_PROFILE);
-        fsRooms = FirebaseStorage.getInstance().getReference().child(STORAGE_ROOM_IMAGE);
         mAppContext = AppApplication.getAppContext();
     }
 
@@ -264,75 +252,4 @@ public class AppUserDataManager implements UserDataManager {
                 onFailureListener);
     }
 
-    @Override
-    public void createKey(@NonNull OnSuccessListener<String> onSuccessListener,
-                          @NonNull OnFailureListener onFailureListener) {
-        dbRooms.push().addListenerForSingleValueEvent(new ValueEventListener() {
-            @Override
-            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-                String key = dataSnapshot.getKey();
-                if (key != null) {
-                    onSuccessListener.onSuccess(key);
-                } else {
-                    onFailureListener.onFailure(new RuntimeException(NETWORK_ERROR));
-                }
-            }
-
-            @Override
-            public void onCancelled(@NonNull DatabaseError databaseError) {
-                onFailureListener.onFailure(new RuntimeException(NETWORK_ERROR));
-            }
-        });
-    }
-
-    @Override
-    public void uploadRoomImage(@NonNull String uuid, @NonNull List<byte[]> imageList,
-                                @NonNull OnSuccessListener<List<String>> onSuccessListener,
-                                @NonNull OnFailureListener onFailureListener) {
-
-        List<String> list = new ArrayList<>();
-        List<StorageReference> innerRef = new ArrayList<>();
-        for (int i = 0; i < imageList.size(); i++) {
-            innerRef.add(fsRooms.child(uuid + "/" + i));
-        }
-        UploadTask uploadTask = innerRef.get(0).putBytes(imageList.remove(0));
-
-        Continuation<UploadTask.TaskSnapshot, Task<Uri>> continuation = task -> {
-            if (!task.isSuccessful()) {
-                onFailureListener.onFailure(new RuntimeException(NETWORK_ERROR));
-            }
-            return innerRef.remove(0).getDownloadUrl();
-        };
-
-
-        OnSuccessListener<Uri> loopListener = new OnSuccessListener<Uri>() {
-            @Override
-            public void onSuccess(Uri uri) {
-                list.add(uri.toString());
-
-                if (!imageList.isEmpty()) {
-                    innerRef.get(0).putBytes(imageList.remove(0))
-                            .continueWithTask(continuation)
-                            .addOnSuccessListener(this)
-                            .addOnFailureListener(onFailureListener);
-                } else {
-                    onSuccessListener.onSuccess(list);
-                }
-            }
-        };
-
-        uploadTask
-                .continueWithTask(continuation)
-                .addOnSuccessListener(loopListener)
-                .addOnFailureListener(onFailureListener);
-    }
-
-    @Override
-    public void uploadRoomData(@NonNull String uuid, @NonNull Room room,
-                               @NonNull OnSuccessListener<Void> onSuccessListener,
-                               @NonNull OnFailureListener onFailureListener) {
-        dbRooms.child(uuid).setValue(room)
-                .addOnSuccessListener(onSuccessListener)
-                .addOnFailureListener(onFailureListener);
-    }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/BottomNavActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/BottomNavActivity.java
@@ -7,11 +7,12 @@ import android.support.v4.view.ViewPager;
 import android.view.MenuItem;
 import android.view.View;
 
+import com.swsnack.catchhouse.Constant;
 import com.swsnack.catchhouse.R;
 import com.swsnack.catchhouse.adapter.ViewPagerAdapter;
-import com.swsnack.catchhouse.Constant;
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.roomsdata.RoomsRepository;
 import com.swsnack.catchhouse.data.userdata.api.AppAPIManager;
 import com.swsnack.catchhouse.data.userdata.remote.AppUserDataManager;
@@ -111,7 +112,11 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
 
     private void createViewModels() {
         createViewModel(UserViewModel.class, new UserViewModelFactory(getApplication(),
-                AppDataManager.getInstance(AppAPIManager.getInstance(), AppUserDataManager.getInstance(), RemoteChattingManager.getInstance()),
+                AppDataManager.getInstance(
+                        AppAPIManager.getInstance(),
+                        AppUserDataManager.getInstance(),
+                        RemoteChattingManager.getInstance(),
+                        AppRoomDataManager.getInstance()),
                 this));
         createViewModel(SearchViewModel.class, new SearchViewModelFactory(getApplication(), RoomsRepository.getInstance(), this));
         createViewModel(ChattingViewModel.class, new ChattingViewModelFactory(this));

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/BottomNavActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/BottomNavActivity.java
@@ -12,6 +12,7 @@ import com.swsnack.catchhouse.R;
 import com.swsnack.catchhouse.adapter.ViewPagerAdapter;
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.locationdata.remote.AppLocationDataManager;
 import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.roomsdata.RoomsRepository;
 import com.swsnack.catchhouse.data.userdata.api.AppAPIManager;
@@ -116,7 +117,8 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
                         AppAPIManager.getInstance(),
                         AppUserDataManager.getInstance(),
                         RemoteChattingManager.getInstance(),
-                        AppRoomDataManager.getInstance()),
+                        AppRoomDataManager.getInstance(),
+                        AppLocationDataManager.getInstance()),
                 this));
         createViewModel(SearchViewModel.class, new SearchViewModelFactory(getApplication(), RoomsRepository.getInstance(), this));
         createViewModel(ChattingViewModel.class, new ChattingViewModelFactory(this));

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/PostActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/PostActivity.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import com.swsnack.catchhouse.R;
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.locationdata.remote.AppLocationDataManager;
 import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.userdata.api.AppAPIManager;
 import com.swsnack.catchhouse.data.userdata.remote.AppUserDataManager;
@@ -41,7 +42,8 @@ public class PostActivity extends BaseActivity<ActivityPostBinding> {
                                 AppAPIManager.getInstance(),
                                 AppUserDataManager.getInstance(),
                                 RemoteChattingManager.getInstance(),
-                                AppRoomDataManager.getInstance()
+                                AppRoomDataManager.getInstance(),
+                                AppLocationDataManager.getInstance()
                         ),
                         this
                 )).get(PostViewModel.class);

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/PostActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/PostActivity.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import com.swsnack.catchhouse.R;
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.userdata.api.AppAPIManager;
 import com.swsnack.catchhouse.data.userdata.remote.AppUserDataManager;
 import com.swsnack.catchhouse.databinding.ActivityPostBinding;
@@ -27,17 +28,22 @@ public class PostActivity extends BaseActivity<ActivityPostBinding> {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mViewModel = ViewModelProviders.of(this,
-                new PostViewModelFactory(
-                AppDataManager.getInstance(
-                        AppAPIManager.getInstance(),
-                        AppUserDataManager.getInstance(),
-                        RemoteChattingManager.getInstance()
-                ),
-                this
-        )).get(PostViewModel.class);
+        createViewModels();
 
         getBinding().setHandler(mViewModel);
         getBinding().setLifecycleOwner(this);
+    }
+
+    private void createViewModels() {
+        mViewModel = ViewModelProviders.of(this,
+                new PostViewModelFactory(
+                        AppDataManager.getInstance(
+                                AppAPIManager.getInstance(),
+                                AppUserDataManager.getInstance(),
+                                RemoteChattingManager.getInstance(),
+                                AppRoomDataManager.getInstance()
+                        ),
+                        this
+                )).get(PostViewModel.class);
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/WriteActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/WriteActivity.java
@@ -16,6 +16,7 @@ import com.swsnack.catchhouse.R;
 import com.swsnack.catchhouse.adapter.slideadapter.ImageSlideAdapter;
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.locationdata.remote.AppLocationDataManager;
 import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.userdata.api.AppAPIManager;
 import com.swsnack.catchhouse.data.userdata.remote.AppUserDataManager;
@@ -152,7 +153,8 @@ public class WriteActivity extends BaseActivity<ActivityWriteBinding> {
                                 AppAPIManager.getInstance(),
                                 AppUserDataManager.getInstance(),
                                 RemoteChattingManager.getInstance(),
-                                AppRoomDataManager.getInstance()
+                                AppRoomDataManager.getInstance(),
+                                AppLocationDataManager.getInstance()
                         ),
                         this
                 )).get(RoomsViewModel.class);

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/WriteActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/WriteActivity.java
@@ -13,14 +13,15 @@ import android.view.View;
 import android.view.WindowManager;
 
 import com.swsnack.catchhouse.R;
+import com.swsnack.catchhouse.adapter.slideadapter.ImageSlideAdapter;
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.userdata.api.AppAPIManager;
 import com.swsnack.catchhouse.data.userdata.remote.AppUserDataManager;
 import com.swsnack.catchhouse.databinding.ActivityWriteBinding;
 import com.swsnack.catchhouse.util.DateCalculator;
 import com.swsnack.catchhouse.view.BaseActivity;
-import com.swsnack.catchhouse.adapter.slideadapter.ImageSlideAdapter;
 import com.swsnack.catchhouse.view.fragment.AddressSearchFragment;
 import com.swsnack.catchhouse.viewmodel.roomsviewmodel.RoomsViewModel;
 import com.swsnack.catchhouse.viewmodel.roomsviewmodel.RoomsViewModelFactory;
@@ -80,19 +81,7 @@ public class WriteActivity extends BaseActivity<ActivityWriteBinding> {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mViewModel = ViewModelProviders.of(this,
-                new RoomsViewModelFactory(
-                        getApplication(),
-                        AppDataManager.getInstance(
-                                AppAPIManager.getInstance(),
-                                AppUserDataManager.getInstance(),
-                                RemoteChattingManager.getInstance()
-                        ),
-                        this
-                )).get(RoomsViewModel.class);
-        
-        getBinding().setHandler(mViewModel);
-        getBinding().setLifecycleOwner(this);
+        createViewModels();
 
         getBinding().vpWrite.setAdapter(new ImageSlideAdapter(mViewModel, mViewModel.mImageList.getValue()));
 
@@ -156,18 +145,20 @@ public class WriteActivity extends BaseActivity<ActivityWriteBinding> {
     }
 
     private void createViewModels() {
-        createViewModel(
-                RoomsViewModel.class,
+        mViewModel = ViewModelProviders.of(this,
                 new RoomsViewModelFactory(
                         getApplication(),
                         AppDataManager.getInstance(
                                 AppAPIManager.getInstance(),
                                 AppUserDataManager.getInstance(),
-                                RemoteChattingManager.getInstance()
+                                RemoteChattingManager.getInstance(),
+                                AppRoomDataManager.getInstance()
                         ),
                         this
-                )
-        );
+                )).get(RoomsViewModel.class);
+
+        getBinding().setHandler(mViewModel);
+        getBinding().setLifecycleOwner(this);
     }
 
     private void createDatePicker(DatePickerDialog.OnDateSetListener listener) {

--- a/app/src/main/java/com/swsnack/catchhouse/view/fragment/MapFragment.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/fragment/MapFragment.java
@@ -15,15 +15,15 @@ import android.widget.Toast;
 
 import com.skt.Tmap.TMapMarkerItem;
 import com.skt.Tmap.TMapPoint;
+import com.skt.Tmap.TMapView;
+import com.swsnack.catchhouse.Constant;
 import com.swsnack.catchhouse.R;
 import com.swsnack.catchhouse.adapter.AddressBindingAdapter;
-import com.swsnack.catchhouse.Constant;
+import com.swsnack.catchhouse.adapter.SimpleDividerItemDecoration;
+import com.swsnack.catchhouse.data.roomsdata.pojo.Address;
 import com.swsnack.catchhouse.databinding.FragmentMapBinding;
 import com.swsnack.catchhouse.view.BaseFragment;
-import com.swsnack.catchhouse.adapter.SimpleDividerItemDecoration;
 import com.swsnack.catchhouse.view.activitity.FilterPopUpActivity;
-import com.swsnack.catchhouse.data.roomsdata.pojo.Address;
-import com.skt.Tmap.TMapView;
 import com.swsnack.catchhouse.viewmodel.searchviewmodel.SearchViewModel;
 
 import io.reactivex.annotations.Nullable;

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/ReactiveViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/ReactiveViewModel.java
@@ -2,7 +2,6 @@ package com.swsnack.catchhouse.viewmodel;
 
 import android.arch.lifecycle.ViewModel;
 
-import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.DataManager;
 
 import io.reactivex.disposables.CompositeDisposable;

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModelFactory.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModelFactory.java
@@ -7,6 +7,7 @@ import android.support.v4.app.Fragment;
 
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.userdata.api.AppAPIManager;
 import com.swsnack.catchhouse.data.userdata.remote.AppUserDataManager;
 import com.swsnack.catchhouse.viewmodel.ViewModelListener;
@@ -25,7 +26,8 @@ public class ChattingViewModelFactory extends ViewModelProvider.NewInstanceFacto
         if (modelClass.isAssignableFrom(ChattingViewModel.class)) {
             return (T) new ChattingViewModel(AppDataManager.getInstance(AppAPIManager.getInstance(),
                     AppUserDataManager.getInstance(),
-                    RemoteChattingManager.getInstance()),
+                    RemoteChattingManager.getInstance(),
+                    AppRoomDataManager.getInstance()),
                     mBottomNavListener);
         }
         throw new Fragment.InstantiationException("not viewModel class", null);

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModelFactory.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModelFactory.java
@@ -7,6 +7,7 @@ import android.support.v4.app.Fragment;
 
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.locationdata.remote.AppLocationDataManager;
 import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.userdata.api.AppAPIManager;
 import com.swsnack.catchhouse.data.userdata.remote.AppUserDataManager;
@@ -27,7 +28,8 @@ public class ChattingViewModelFactory extends ViewModelProvider.NewInstanceFacto
             return (T) new ChattingViewModel(AppDataManager.getInstance(AppAPIManager.getInstance(),
                     AppUserDataManager.getInstance(),
                     RemoteChattingManager.getInstance(),
-                    AppRoomDataManager.getInstance()),
+                    AppRoomDataManager.getInstance(),
+                    AppLocationDataManager.getInstance()),
                     mBottomNavListener);
         }
         throw new Fragment.InstantiationException("not viewModel class", null);

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/roomsviewmodel/RoomsViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/roomsviewmodel/RoomsViewModel.java
@@ -130,18 +130,14 @@ public class RoomsViewModel extends ReactiveViewModel {
     }
 
     public void onSearchAddress() {
-        List<Address> addressList = mSearchResultList.getValue();
 
         getCompositeDisposable().add(searchAddress()
-                .subscribe(list -> {
-                            addressList.addAll(list);
-                            mSearchResultList.postValue(addressList);
-                        }, exception ->
+                .subscribe(list ->
+                                mSearchResultList.postValue(list)
+                        , exception ->
                                 mListener.onError("error")
                 )
         );
-
-        mSearchResultList.setValue(addressList);
     }
 
     public void onSelectAddress(int position) {

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/roomsviewmodel/RoomsViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/roomsviewmodel/RoomsViewModel.java
@@ -145,7 +145,9 @@ public class RoomsViewModel extends ReactiveViewModel {
             List<Address> addressList = mSearchResultList.getValue();
 
             mAddress.setValue(addressList.get(position));
+
             addressList.clear();
+            mKeyword.setValue("");
             mSearchResultList.setValue(addressList);
         }
     }

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/searchviewmodel/SearchViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/searchviewmodel/SearchViewModel.java
@@ -5,6 +5,7 @@ import android.arch.lifecycle.MutableLiveData;
 
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.locationdata.remote.AppLocationDataManager;
 import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.roomsdata.RoomsRepository;
 import com.swsnack.catchhouse.data.roomsdata.pojo.Address;
@@ -31,7 +32,8 @@ public class SearchViewModel extends ReactiveViewModel {
         super(AppDataManager.getInstance(AppAPIManager.getInstance(),
                 AppUserDataManager.getInstance(),
                 RemoteChattingManager.getInstance(),
-                AppRoomDataManager.getInstance()));
+                AppRoomDataManager.getInstance(),
+                AppLocationDataManager.getInstance()));
         mAppContext = application;
         mRepository = repository;
         mListener = listener;

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/searchviewmodel/SearchViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/searchviewmodel/SearchViewModel.java
@@ -5,6 +5,7 @@ import android.arch.lifecycle.MutableLiveData;
 
 import com.swsnack.catchhouse.data.AppDataManager;
 import com.swsnack.catchhouse.data.chattingdata.remote.RemoteChattingManager;
+import com.swsnack.catchhouse.data.roomdata.remote.AppRoomDataManager;
 import com.swsnack.catchhouse.data.roomsdata.RoomsRepository;
 import com.swsnack.catchhouse.data.roomsdata.pojo.Address;
 import com.swsnack.catchhouse.data.userdata.api.AppAPIManager;
@@ -27,7 +28,10 @@ public class SearchViewModel extends ReactiveViewModel {
     public MutableLiveData<String> mKeyword;
 
     SearchViewModel(Application application, RoomsRepository repository, ViewModelListener listener) {
-        super(AppDataManager.getInstance(AppAPIManager.getInstance(), AppUserDataManager.getInstance(), RemoteChattingManager.getInstance()));
+        super(AppDataManager.getInstance(AppAPIManager.getInstance(),
+                AppUserDataManager.getInstance(),
+                RemoteChattingManager.getInstance(),
+                AppRoomDataManager.getInstance()));
         mAppContext = application;
         mRepository = repository;
         mListener = listener;

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ ext {
     firebaseStorageVersion = '16.0.5'
     googleAuthVersion = '16.0.1'
     facebookAuthVersion = '4.39.0'
+    geofireVersion = "2.3.1"
     glideVersion = '4.8.0'
     glideTransformVersion = '4.0.0'
     multidexVersion = '1.0.3'


### PR DESCRIPTION
## 개요
- 데이터 매니저 DB 테이블 마다 독립된 매니저 갖도록 수정
- 방 판매글 올릴 때 위치 정보도 위치 테이블에 올리는 기능 추가

## 구현사항
- RoomDataManager, LocationDataManager 추가
- T Map으로 주소 검색
- FireGeo로 위치 정보 데이터베이스에 저장


## 리뷰 요청사항
- 


resolve: #60 
