### PR TITLE
채팅 기능 구현

### DIFF
--- a/app/src/main/java/com/swsnack/catchhouse/Constant.java
+++ b/app/src/main/java/com/swsnack/catchhouse/Constant.java
@@ -29,6 +29,7 @@ import static com.swsnack.catchhouse.Constant.FirebaseKey.MESSAGE;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.NICK_NAME;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_PROFILE;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_ROOM_IMAGE;
+import static com.swsnack.catchhouse.Constant.FirebaseKey.UUID;
 import static com.swsnack.catchhouse.Constant.Gender.FEMALE;
 import static com.swsnack.catchhouse.Constant.Gender.MALE;
 import static com.swsnack.catchhouse.Constant.ParcelableData.CHATTING_DATA;
@@ -41,12 +42,13 @@ import static com.swsnack.catchhouse.Constant.PostException.NOT_SELECTION_DATE;
 import static com.swsnack.catchhouse.Constant.SignInMethod.E_MAIL;
 import static com.swsnack.catchhouse.Constant.SignInMethod.FACEBOOK;
 import static com.swsnack.catchhouse.Constant.SignInMethod.GOOGLE;
-import static com.swsnack.catchhouse.Constant.UserStatus.DELETE_USER_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.SIGN_IN_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.SIGN_UP_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.UPDATE_NICK_NAME_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.UPDATE_PASSWORD_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.UPDATE_PROFILE_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.DELETE_USER_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.SEND_MESSAGE_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.SIGN_IN_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.SIGN_UP_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.UPDATE_NICK_NAME_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.UPDATE_PASSWORD_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.UPDATE_PROFILE_SUCCESS;
 
 public class Constant {
 
@@ -58,14 +60,15 @@ public class Constant {
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({SIGN_IN_SUCCESS, SIGN_UP_SUCCESS, DELETE_USER_SUCCESS, UPDATE_NICK_NAME_SUCCESS,
-            UPDATE_PASSWORD_SUCCESS, UPDATE_PROFILE_SUCCESS})
-    public @interface UserStatus {
+            UPDATE_PASSWORD_SUCCESS, UPDATE_PROFILE_SUCCESS, SEND_MESSAGE_SUCCESS})
+    public @interface SuccessKey {
         String SIGN_IN_SUCCESS = "singInSuccess";
         String SIGN_UP_SUCCESS = "signUpSuccess";
         String DELETE_USER_SUCCESS = "deleteSuccess";
         String UPDATE_NICK_NAME_SUCCESS = "updateNickNameSuccess";
         String UPDATE_PASSWORD_SUCCESS = "updatePasswordSuccess";
         String UPDATE_PROFILE_SUCCESS = "updateProfileSuccess";
+        String SEND_MESSAGE_SUCCESS = "sendMessageSuccess";
     }
 
     //magic constant
@@ -89,7 +92,7 @@ public class Constant {
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({DB_USER, STORAGE_PROFILE, STORAGE_ROOM_IMAGE, NICK_NAME, CHATTING,
-            MESSAGE})
+            MESSAGE, UUID})
     public @interface FirebaseKey {
         String DB_USER = "users";
         String DB_ROOM = "rooms";
@@ -98,6 +101,7 @@ public class Constant {
         String NICK_NAME = "nickName";
         String CHATTING = "chatting";
         String MESSAGE = "messages";
+        String UUID = "uuid";
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/app/src/main/java/com/swsnack/catchhouse/Constant.java
+++ b/app/src/main/java/com/swsnack/catchhouse/Constant.java
@@ -97,7 +97,7 @@ public class Constant {
         String STORAGE_ROOM_IMAGE = "roomImage";
         String NICK_NAME = "nickName";
         String CHATTING = "chatting";
-        String MESSAGE = "message";
+        String MESSAGE = "messages";
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/app/src/main/java/com/swsnack/catchhouse/Constant.java
+++ b/app/src/main/java/com/swsnack/catchhouse/Constant.java
@@ -25,6 +25,7 @@ import static com.swsnack.catchhouse.Constant.FacebookData.NAME;
 import static com.swsnack.catchhouse.Constant.FacebookData.VALUE;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.CHATTING;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_USER;
+import static com.swsnack.catchhouse.Constant.FirebaseKey.MESSAGE;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.NICK_NAME;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_PROFILE;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_ROOM_IMAGE;
@@ -87,7 +88,8 @@ public class Constant {
     }
 
     @Retention(RetentionPolicy.SOURCE)
-    @StringDef({DB_USER, STORAGE_PROFILE, STORAGE_ROOM_IMAGE, NICK_NAME, CHATTING})
+    @StringDef({DB_USER, STORAGE_PROFILE, STORAGE_ROOM_IMAGE, NICK_NAME, CHATTING,
+            MESSAGE})
     public @interface FirebaseKey {
         String DB_USER = "users";
         String DB_ROOM = "rooms";
@@ -95,6 +97,7 @@ public class Constant {
         String STORAGE_ROOM_IMAGE = "roomImage";
         String NICK_NAME = "nickName";
         String CHATTING = "chatting";
+        String MESSAGE = "message";
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/BaseDiffUtil.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/BaseDiffUtil.java
@@ -1,6 +1,9 @@
 package com.swsnack.catchhouse.adapter;
 
 import android.support.v7.util.DiffUtil;
+import android.util.Log;
+
+import com.swsnack.catchhouse.data.chattingdata.model.Message;
 
 import java.util.List;
 
@@ -26,6 +29,7 @@ public abstract class BaseDiffUtil<T> extends DiffUtil.Callback {
 
     @Override
     public boolean areItemsTheSame(int i, int i1) {
+        Log.d("값", "" + mOldList.get(i).equals(mNewList.get(i1)));
         return mOldList.get(i).equals(mNewList.get(i1));
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/BaseDiffUtil.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/BaseDiffUtil.java
@@ -28,8 +28,7 @@ public abstract class BaseDiffUtil<T> extends DiffUtil.Callback {
     }
 
     @Override
-    public boolean areItemsTheSame(int i, int i1) {
-        Log.d("값", "" + mOldList.get(i).equals(mNewList.get(i1)));
-        return mOldList.get(i).equals(mNewList.get(i1));
+    public boolean areItemsTheSame(int oldListIndex, int newListIndex) {
+        return mOldList.get(oldListIndex).equals(mNewList.get(newListIndex));
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/bindingadapter/ChattingDataBinding.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/bindingadapter/ChattingDataBinding.java
@@ -23,7 +23,8 @@ public class ChattingDataBinding {
     @BindingAdapter({"setChattingList"})
     public static void setList(RecyclerView recyclerView, List<Chatting> chattingList) {
         ChattingListAdapter chattingListAdapter = (ChattingListAdapter) recyclerView.getAdapter();
-        chattingListAdapter.setList(chattingList);
+        List<Chatting> orderedList = DataConverter.reOrderedListByTimeStamp(chattingList);
+        chattingListAdapter.setList(orderedList);
     }
 
     @BindingAdapter({"setChattingUserProfile"})
@@ -40,13 +41,13 @@ public class ChattingDataBinding {
 
     @BindingAdapter({"setChattingMessage"})
     public static void setMessage(RecyclerView recyclerView, List<Message> chattingMessages) {
-        if (chattingMessages == null) {
+        if (chattingMessages == null || chattingMessages.size() == 0) {
             return;
         }
 
         ChattingMessageAdapter chattingMessageAdapter = (ChattingMessageAdapter) recyclerView.getAdapter();
         chattingMessageAdapter.setList(chattingMessages);
-        recyclerView.smoothScrollToPosition(chattingMessages.size() - 1);
+        recyclerView.scrollToPosition(chattingMessages.size() - 1);
     }
 
     @BindingAdapter({"setUserData"})

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/bindingadapter/ChattingDataBinding.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/bindingadapter/ChattingDataBinding.java
@@ -39,15 +39,13 @@ public class ChattingDataBinding {
     }
 
     @BindingAdapter({"setChattingMessage"})
-    public static void setMessage(RecyclerView recyclerView, Chatting chattingMessages) {
+    public static void setMessage(RecyclerView recyclerView, List<Message> chattingMessages) {
         if (chattingMessages == null) {
             return;
         }
 
-        if (chattingMessages.getMessage() != null) {
-            ChattingMessageAdapter chattingMessageAdapter = (ChattingMessageAdapter) recyclerView.getAdapter();
-            chattingMessageAdapter.setList(DataConverter.sortByValueFromMapToList(chattingMessages.getMessage()));
-        }
+        ChattingMessageAdapter chattingMessageAdapter = (ChattingMessageAdapter) recyclerView.getAdapter();
+        chattingMessageAdapter.setList(chattingMessages);
     }
 
     @BindingAdapter({"setUserData"})

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/bindingadapter/ChattingDataBinding.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/bindingadapter/ChattingDataBinding.java
@@ -46,6 +46,7 @@ public class ChattingDataBinding {
 
         ChattingMessageAdapter chattingMessageAdapter = (ChattingMessageAdapter) recyclerView.getAdapter();
         chattingMessageAdapter.setList(chattingMessages);
+        recyclerView.smoothScrollToPosition(chattingMessages.size() - 1);
     }
 
     @BindingAdapter({"setUserData"})

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/bindingadapter/ChattingDataBinding.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/bindingadapter/ChattingDataBinding.java
@@ -20,13 +20,13 @@ import java.util.List;
 
 public class ChattingDataBinding {
 
-    @BindingAdapter({"setList"})
+    @BindingAdapter({"setChattingList"})
     public static void setList(RecyclerView recyclerView, List<Chatting> chattingList) {
         ChattingListAdapter chattingListAdapter = (ChattingListAdapter) recyclerView.getAdapter();
         chattingListAdapter.setList(chattingList);
     }
 
-    @BindingAdapter({"setChattingListProfile"})
+    @BindingAdapter({"setChattingUserProfile"})
     public static void setProfile(ImageView imageView, User user) {
         if (user == null) {
             return;
@@ -46,8 +46,6 @@ public class ChattingDataBinding {
 
         if (chattingMessages.getMessage() != null) {
             ChattingMessageAdapter chattingMessageAdapter = (ChattingMessageAdapter) recyclerView.getAdapter();
-            List<Message> messages = DataConverter.sortByValueFromMapToList(chattingMessages.getMessage());
-            Log.d("메세지", "setMessage: " + messages);
             chattingMessageAdapter.setList(DataConverter.sortByValueFromMapToList(chattingMessages.getMessage()));
         }
     }

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingDiffUtil.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingDiffUtil.java
@@ -15,27 +15,12 @@ public class ChattingDiffUtil extends BaseDiffUtil<Chatting> {
     }
 
     @Override
-    public boolean areContentsTheSame(int i, int i1) {
-        if (mOldList.get(i).getMessage() != null && mNewList.get(i1).getMessage() != null) {
-            Map<String, Message> oldMessages = mOldList.get(i).getMessage();
-            Map<String, Message> newMessages = mNewList.get(i1).getMessage();
-
-            if (oldMessages.size() != newMessages.size()) {
-                return false;
-            }
-
-            Iterator<String> oldMessageIter = oldMessages.keySet().iterator();
-            Iterator<String> newMessageIter = newMessages.keySet().iterator();
-
-            while (oldMessageIter.hasNext() && newMessageIter.hasNext()) {
-                Message oldMessage = oldMessages.get(oldMessageIter.next());
-                Message newMessage = newMessages.get(newMessageIter.next());
-
-                if (!oldMessage.getTimestamp().equals(newMessage.getTimestamp()) || !oldMessage.getContent().equals(newMessage.getContent())) {
-                    return false;
-                }
-            }
+    public boolean areContentsTheSame(int oldMessageIndex, int newMessageIndex) {
+        if (mOldList.get(oldMessageIndex).getMessages() != null && mNewList.get(newMessageIndex).getMessages() != null) {
+            List<Message> oldMessages = mOldList.get(oldMessageIndex).getMessages();
+            List<Message> newMessages = mNewList.get(newMessageIndex).getMessages();
+            return oldMessages.get(oldMessages.size() -1).equals(newMessages.get(newMessages.size() -1));
         }
-        return true;
+        return false;
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingListAdapter.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingListAdapter.java
@@ -55,7 +55,7 @@ public class ChattingListAdapter extends BaseRecyclerViewAdapter<Chatting, Chatt
     }
 
     @Override
-    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         super.onBindViewHolder(holder, position);
 
         ItemChattingListBinding binding = ((ChattingListItemHolder) holder).getBinding();
@@ -64,8 +64,8 @@ public class ChattingListAdapter extends BaseRecyclerViewAdapter<Chatting, Chatt
                 binding::setUserData,
                 error -> Snackbar.make(binding.getRoot(), R.string.snack_failed_load_list, Snackbar.LENGTH_SHORT).show());
 
-        if (arrayList.get(position).getMessage() != null) {
-            List<Message> messages = DataConverter.sortByValueFromMapToList(arrayList.get(position).getMessage());
+        if (arrayList.get(position).getMessages() != null) {
+            List<Message> messages = arrayList.get(position).getMessages();
             binding.tvChattingListLastMessage.setText(messages.get(messages.size() - 1).getContent());
         } else {
             binding.tvChattingListLastMessage.setText("");

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingMessageAdapter.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingMessageAdapter.java
@@ -65,6 +65,7 @@ public class ChattingMessageAdapter extends BaseRecyclerViewAdapter<Message, Cha
         ChattingMessageItemHolder viewHolder = new ChattingMessageItemHolder(binding);
         binding.setLifecycleOwner(viewHolder);
         binding.setHandler(mChattingViewModel);
+        binding.setUserData(mUserData);
 
         return viewHolder;
     }

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingMessageAdapter.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingMessageAdapter.java
@@ -5,6 +5,7 @@ import android.databinding.DataBindingUtil;
 import android.support.annotation.NonNull;
 import android.support.v7.util.DiffUtil;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingMessageDiffUtil.java
+++ b/app/src/main/java/com/swsnack/catchhouse/adapter/chattingadapter/ChattingMessageDiffUtil.java
@@ -13,7 +13,6 @@ public class ChattingMessageDiffUtil extends BaseDiffUtil<Message> {
 
     @Override
     public boolean areContentsTheSame(int i, int i1) {
-        return mOldList.get(i).getTimestamp().equals(mNewList.get(i1).getTimestamp())
-                && mOldList.get(i).getContent().equals(mNewList.get(i1).getContent());
+        return mOldList.get(i).getContent().equals(mNewList.get(i1).getContent());
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -247,7 +247,7 @@ public class AppDataManager implements DataManager {
 
     @Override
     public void getChatMessage(@NonNull String chatRoomId,
-                               @NonNull OnSuccessListener<Map<String, Message>> onSuccessListener,
+                               @NonNull OnSuccessListener<List<Message>> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
 
         mRemoteChattingManager.getChatMessage(chatRoomId, onSuccessListener, onFailureListener);
@@ -260,11 +260,12 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void setChatMessage(@NonNull Message message,
+    public void setChatMessage(@NonNull String roomUid,
+                               @NonNull Message message,
                                @NonNull OnSuccessListener<Void> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
 
-        mRemoteChattingManager.setChatMessage(message, onSuccessListener, onFailureListener);
+        mRemoteChattingManager.setChatMessage(roomUid, message, onSuccessListener, onFailureListener);
 
     }
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -21,7 +21,6 @@ import com.swsnack.catchhouse.data.userdata.UserDataManager;
 import com.swsnack.catchhouse.data.userdata.model.User;
 
 import java.util.List;
-import java.util.Map;
 
 import static com.swsnack.catchhouse.Constant.ExceptionReason.NOT_SIGNED_USER;
 
@@ -72,12 +71,7 @@ public class AppDataManager implements DataManager {
                         setUser(signUpSuccess.getUser().getUid(), user, onSuccessListener, onFailureListener);
                         return;
                     }
-                    uploadProfile(signUpSuccess.getUser().getUid(),
-                            uri,
-                            storageUri -> {
-                                user.setProfile(storageUri.toString());
-                                setUser(signUpSuccess.getUser().getUid(), user, onSuccessListener, onFailureListener);
-                            }, onFailureListener);
+                    setUser(signUpSuccess.getUser().getUid(), user, onSuccessListener, onFailureListener);
                 },
                 onFailureListener);
     }
@@ -87,6 +81,7 @@ public class AppDataManager implements DataManager {
                                  @NonNull User user,
                                  @NonNull OnSuccessListener<Void> onSuccessListener,
                                  @NonNull OnFailureListener onFailureListener) {
+
         signUp(authCredential,
                 signUpSuccess ->
                         getUserFromSingleSnapShot(signUpSuccess.getUser().getUid(),
@@ -103,61 +98,54 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void deleteUserAll(@NonNull String uuid, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void deleteUserAll(@NonNull String uuid,
+                              @NonNull User user,
+                              @NonNull OnSuccessListener<Void> onSuccessListener,
+                              @NonNull OnFailureListener onFailureListener) {
+
         if (FirebaseAuth.getInstance().getCurrentUser() == null) {
             onFailureListener.onFailure(new FirebaseException(NOT_SIGNED_USER));
             return;
         }
-        // FIXME callback이 4개가 중첩되어있는 콜백지옥 구조인데 이런방식은 아주 좋지 않습니다. 개선할 방법을 고민하셔서 간결한 코드로 수정해주세요
-        getUserFromSingleSnapShot(uuid,
-                user ->
-                        deleteUserData(uuid,
-                                deleteDB -> {
-                                    if (user.getProfile() == null) {
-                                        deleteUser(onSuccessListener,
-                                                error -> {
-                                                    onFailureListener.onFailure(error);
-                                                    setUser(uuid, user,
-                                                            Void -> {
-                                                            },
-                                                            transactionError -> {
-                                                            });
-                                                });
-                                        return;
-                                    }
-                                    deleteProfile(uuid,
-                                            deleteProfile ->
-                                                    deleteUser(onSuccessListener, onFailureListener),
-                                            error -> {
-                                                onFailureListener.onFailure(error);
-                                                setUser(uuid, user,
-                                                        Void -> {
-                                                        },
-                                                        transactionError -> {
-                                                        });
-                                            });
-                                },
-                                onFailureListener),
+
+        deleteUserData(uuid, user,
+                deleteUserSuccess -> deleteUser(onSuccessListener, onFailureListener),
                 onFailureListener);
     }
 
     @Override
-    public void updateProfile(@NonNull String uuid, @NonNull Uri uri, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
-        mUserDataManager.updateProfile(uuid, uri, onSuccessListener, onFailureListener);
+    public void updateProfile(@NonNull String uuid,
+                              @NonNull Uri uri,
+                              @NonNull User user,
+                              @NonNull OnSuccessListener<Void> onSuccessListener,
+                              @NonNull OnFailureListener onFailureListener) {
+
+        mUserDataManager.updateProfile(uuid, uri, user, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void signUp(@NonNull AuthCredential authCredential, @NonNull OnSuccessListener<AuthResult> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void signUp(@NonNull AuthCredential authCredential,
+                       @NonNull OnSuccessListener<AuthResult> onSuccessListener,
+                       @NonNull OnFailureListener onFailureListener) {
+
         mApiManager.signUp(authCredential, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void signUp(@NonNull String email, @NonNull String password, @NonNull OnSuccessListener<AuthResult> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void signUp(@NonNull String email,
+                       @NonNull String password,
+                       @NonNull OnSuccessListener<AuthResult> onSuccessListener,
+                       @NonNull OnFailureListener onFailureListener) {
+
         mApiManager.signUp(email, password, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void signIn(@NonNull String email, @NonNull String password, @NonNull OnSuccessListener<AuthResult> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void signIn(@NonNull String email,
+                       @NonNull String password,
+                       @NonNull OnSuccessListener<AuthResult> onSuccessListener,
+                       @NonNull OnFailureListener onFailureListener) {
+
         mApiManager.signIn(email, password, onSuccessListener, onFailureListener);
     }
 
@@ -167,12 +155,19 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void updatePassword(@NonNull String oldPassword, @NonNull String newPassword, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void updatePassword(@NonNull String oldPassword,
+                               @NonNull String newPassword,
+                               @NonNull OnSuccessListener<Void> onSuccessListener,
+                               @NonNull OnFailureListener onFailureListener) {
+
         mApiManager.updatePassword(oldPassword, newPassword, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void getUserInfoFromFacebook(@NonNull AccessToken accessToken, @NonNull OnSuccessListener<User> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void getUserInfoFromFacebook(@NonNull AccessToken accessToken,
+                                        @NonNull OnSuccessListener<User> onSuccessListener,
+                                        @NonNull OnFailureListener onFailureListener) {
+
         mApiManager.getUserInfoFromFacebook(accessToken, onSuccessListener, onFailureListener);
     }
 
@@ -191,17 +186,38 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void setUser(@NonNull String uuid, @NonNull User user, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void setUser(@NonNull String uuid,
+                        @NonNull User user,
+                        @NonNull OnSuccessListener<Void> onSuccessListener,
+                        @NonNull OnFailureListener onFailureListener) {
+
         mUserDataManager.setUser(uuid, user, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void deleteUserData(@NonNull String uuid, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
-        mUserDataManager.deleteUserData(uuid, onSuccessListener, onFailureListener);
+    public void setUser(@NonNull String uuid,
+                        @NonNull User user,
+                        @NonNull Uri uri,
+                        @NonNull OnSuccessListener<Void> onSuccessListener,
+                        @NonNull OnFailureListener onFailureListener) {
+
+        mUserDataManager.setUser(uuid, user, uri, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void deleteProfile(@NonNull String uuid, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void deleteUserData(@NonNull String uuid,
+                               @NonNull User user,
+                               @NonNull OnSuccessListener<Void> onSuccessListener,
+                               @NonNull OnFailureListener onFailureListener) {
+
+        mUserDataManager.deleteUserData(uuid, user, onSuccessListener, onFailureListener);
+    }
+
+    @Override
+    public void deleteProfile(@NonNull String uuid,
+                              @NonNull OnSuccessListener<Void> onSuccessListener,
+                              @NonNull OnFailureListener onFailureListener) {
+
         mUserDataManager.deleteProfile(uuid, onSuccessListener, onFailureListener);
     }
 
@@ -215,32 +231,36 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void updateUser(@NonNull String uuid, @NonNull Map<String, Object> updateFields, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
-        mUserDataManager.updateUser(uuid, updateFields, onSuccessListener, onFailureListener);
+    public void updateUser(@NonNull String uuid,
+                           @NonNull User user,
+                           @NonNull OnSuccessListener<Void> onSuccessListener,
+                           @NonNull OnFailureListener onFailureListener) {
+
+        mUserDataManager.updateUser(uuid, user, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void updateNickName(@NonNull String uuid, @NonNull String changeNickName, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
-        mUserDataManager.updateNickName(uuid, changeNickName, onSuccessListener, onFailureListener);
-    }
+    public void getProfile(@NonNull Uri uri,
+                           @NonNull OnSuccessListener<Bitmap> onSuccessListener,
+                           @NonNull OnFailureListener onFailureListener) {
 
-    @Override
-    public void uploadProfile(@NonNull String uuid, @NonNull Uri imageUri, @NonNull OnSuccessListener<Uri> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
-        mUserDataManager.uploadProfile(uuid, imageUri, onSuccessListener, onFailureListener);
-    }
-
-    @Override
-    public void getProfile(@NonNull Uri uri, @NonNull OnSuccessListener<Bitmap> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
         mUserDataManager.getProfile(uri, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void getChattingRoom(@NonNull String uuid, @NonNull String destinationUuid, @NonNull OnSuccessListener<String> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void getChattingRoom(@NonNull String uuid,
+                                @NonNull String destinationUuid,
+                                @NonNull OnSuccessListener<String> onSuccessListener,
+                                @NonNull OnFailureListener onFailureListener) {
+
         mRemoteChattingManager.getChattingRoom(uuid, destinationUuid, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void getChattingList(@NonNull String uuid, @NonNull OnSuccessListener<List<Chatting>> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void getChattingList(@NonNull String uuid,
+                                @NonNull OnSuccessListener<List<Chatting>> onSuccessListener,
+                                @NonNull OnFailureListener onFailureListener) {
+
         mRemoteChattingManager.getChattingList(uuid, onSuccessListener, onFailureListener);
     }
 
@@ -264,7 +284,10 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void setChattingRoom(@NonNull Chatting chattingUser, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void setChattingRoom(@NonNull Chatting chattingUser,
+                                @NonNull OnSuccessListener<Void> onSuccessListener,
+                                @NonNull OnFailureListener onFailureListener) {
+
         mRemoteChattingManager.setChattingRoom(chattingUser, onSuccessListener, onFailureListener);
     }
 
@@ -281,6 +304,7 @@ public class AppDataManager implements DataManager {
     @Override
     public void createKey(@NonNull OnSuccessListener<String> onSuccessListener,
                           @NonNull OnFailureListener onFailureListener) {
+
         mUserDataManager.createKey(onSuccessListener, onFailureListener);
     }
 
@@ -288,6 +312,7 @@ public class AppDataManager implements DataManager {
     public void uploadRoomImage(@NonNull String uuid, @NonNull List<byte[]> imageList,
                                 @NonNull OnSuccessListener<List<String>> onSuccessListener,
                                 @NonNull OnFailureListener onFailureListener) {
+
         mUserDataManager.uploadRoomImage(uuid, imageList, onSuccessListener, onFailureListener);
     }
 
@@ -295,6 +320,7 @@ public class AppDataManager implements DataManager {
     public void uploadRoomData(@NonNull String uuid, @NonNull Room room,
                                @NonNull OnSuccessListener<Void> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
+
         mUserDataManager.uploadRoomData(uuid, room, onSuccessListener, onFailureListener);
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -12,7 +12,6 @@ import com.google.firebase.FirebaseException;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.database.ValueEventListener;
 import com.swsnack.catchhouse.data.chattingdata.ChattingManager;
 import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.data.chattingdata.model.Message;
@@ -243,6 +242,11 @@ public class AppDataManager implements DataManager {
     @Override
     public void getChattingList(@NonNull String uuid, @NonNull OnSuccessListener<List<Chatting>> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
         mRemoteChattingManager.getChattingList(uuid, onSuccessListener, onFailureListener);
+    }
+
+    @Override
+    public void removeChattingListListener() {
+        mRemoteChattingManager.removeChattingListListener();
     }
 
     @Override

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -284,20 +284,21 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void setChattingRoom(@NonNull Chatting chattingUser,
+    public void setChattingRoom(@NonNull Chatting chatting,
                                 @NonNull OnSuccessListener<Void> onSuccessListener,
                                 @NonNull OnFailureListener onFailureListener) {
 
-        mRemoteChattingManager.setChattingRoom(chattingUser, onSuccessListener, onFailureListener);
+        mRemoteChattingManager.setChattingRoom(chatting, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void setChatMessage(@NonNull String roomUid,
-                               @NonNull Message message,
+    public void setChatMessage(int messagesLength,
+                               @NonNull String roomUid,
+                               @NonNull String content,
                                @NonNull OnSuccessListener<Void> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
 
-        mRemoteChattingManager.setChatMessage(roomUid, message, onSuccessListener, onFailureListener);
+        mRemoteChattingManager.setChatMessage(messagesLength, roomUid, content, onSuccessListener, onFailureListener);
 
     }
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -245,8 +245,8 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void removeChattingListListener() {
-        mRemoteChattingManager.removeChattingListListener();
+    public void cancelChattingModelObserving() {
+        mRemoteChattingManager.cancelChattingModelObserving();
     }
 
     @Override
@@ -256,6 +256,11 @@ public class AppDataManager implements DataManager {
 
         mRemoteChattingManager.getChatMessage(chatRoomId, onSuccessListener, onFailureListener);
 
+    }
+
+    @Override
+    public void cancelMessageModelObserving() {
+        mRemoteChattingManager.cancelMessageModelObserving();
     }
 
     @Override

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -42,9 +42,12 @@ public class AppDataManager implements DataManager {
                            ChattingManager remoteChattingManager,
                            RoomDataManager roomDataManager,
                            LocationDataManager locationDataManager) {
+
         mApiManager = apiManager;
         mUserDataManager = userDataManager;
         mRemoteChattingManager = remoteChattingManager;
+        mRoomDataManager = roomDataManager;
+        mLocationDataManager = locationDataManager;
     }
 
     private static AppDataManager INSTANCE;
@@ -314,11 +317,14 @@ public class AppDataManager implements DataManager {
                                @NonNull OnSuccessListener<String> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
 
+        mRemoteChattingManager.setChatMessage(messagesLength, roomUid, destinationUid, content, onSuccessListener, onFailureListener);
+
     }
 
     @Override
     public void createKey(@NonNull OnSuccessListener<String> onSuccessListener,
                           @NonNull OnFailureListener onFailureListener) {
+
         mRoomDataManager.createKey(onSuccessListener, onFailureListener);
     }
 
@@ -326,6 +332,7 @@ public class AppDataManager implements DataManager {
     public void uploadRoomImage(@NonNull String uuid, @NonNull List<byte[]> imageList,
                                 @NonNull OnSuccessListener<List<String>> onSuccessListener,
                                 @NonNull OnFailureListener onFailureListener) {
+
         mRoomDataManager.uploadRoomImage(uuid, imageList, onSuccessListener, onFailureListener);
     }
 
@@ -333,6 +340,7 @@ public class AppDataManager implements DataManager {
     public void uploadRoomData(@NonNull String uuid, @NonNull Room room,
                                @NonNull OnSuccessListener<Void> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
+
         mRoomDataManager.uploadRoomData(uuid, room, onSuccessListener, onFailureListener);
     }
 
@@ -340,6 +348,7 @@ public class AppDataManager implements DataManager {
     public void uploadLocationData(@NonNull String uuid, @NonNull Address address,
                                    @NonNull OnSuccessListener<String> onSuccessListener,
                                    @NonNull OnFailureListener onFailureListener) {
+
         mLocationDataManager.uploadLocationData(uuid, address, onSuccessListener, onFailureListener);
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -119,8 +119,10 @@ public class AppDataManager implements DataManager {
                                                 error -> {
                                                     onFailureListener.onFailure(error);
                                                     setUser(uuid, user,
-                                                            Void -> {},
-                                                            transactionError -> {});
+                                                            Void -> {
+                                                            },
+                                                            transactionError -> {
+                                                            });
                                                 });
                                         return;
                                     }
@@ -130,8 +132,10 @@ public class AppDataManager implements DataManager {
                                             error -> {
                                                 onFailureListener.onFailure(error);
                                                 setUser(uuid, user,
-                                                        Void -> {},
-                                                        transactionError -> {});
+                                                        Void -> {
+                                                        },
+                                                        transactionError -> {
+                                                        });
                                             });
                                 },
                                 onFailureListener),
@@ -242,7 +246,11 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void getChatMessage(@NonNull String chatRoomId, @NonNull ValueEventListener valueEventListener) {
+    public void getChatMessage(@NonNull String chatRoomId,
+                               @NonNull OnSuccessListener<Map<String, Message>> onSuccessListener,
+                               @NonNull OnFailureListener onFailureListener) {
+
+        mRemoteChattingManager.getChatMessage(chatRoomId, onSuccessListener, onFailureListener);
 
     }
 
@@ -252,7 +260,11 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void setChatMessage(@NonNull Message message, @NonNull ValueEventListener valueEventListener) {
+    public void setChatMessage(@NonNull Message message,
+                               @NonNull OnSuccessListener<Void> onSuccessListener,
+                               @NonNull OnFailureListener onFailureListener) {
+
+        mRemoteChattingManager.setChatMessage(message, onSuccessListener, onFailureListener);
 
     }
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/AppDataManager.java
@@ -248,20 +248,18 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void getChattingRoom(@NonNull String uuid,
-                                @NonNull String destinationUuid,
+    public void getChattingRoom(@NonNull String destinationUuid,
                                 @NonNull OnSuccessListener<String> onSuccessListener,
                                 @NonNull OnFailureListener onFailureListener) {
 
-        mRemoteChattingManager.getChattingRoom(uuid, destinationUuid, onSuccessListener, onFailureListener);
+        mRemoteChattingManager.getChattingRoom(destinationUuid, onSuccessListener, onFailureListener);
     }
 
     @Override
-    public void getChattingList(@NonNull String uuid,
-                                @NonNull OnSuccessListener<List<Chatting>> onSuccessListener,
+    public void getChattingList(@NonNull OnSuccessListener<List<Chatting>> onSuccessListener,
                                 @NonNull OnFailureListener onFailureListener) {
 
-        mRemoteChattingManager.getChattingList(uuid, onSuccessListener, onFailureListener);
+        mRemoteChattingManager.getChattingList(onSuccessListener, onFailureListener);
     }
 
     @Override
@@ -270,11 +268,11 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void getChatMessage(@NonNull String chatRoomId,
-                               @NonNull OnSuccessListener<List<Message>> onSuccessListener,
-                               @NonNull OnFailureListener onFailureListener) {
+    public void listeningForChangedChatMessage(@NonNull String chatRoomId,
+                                               @NonNull OnSuccessListener<List<Message>> onSuccessListener,
+                                               @NonNull OnFailureListener onFailureListener) {
 
-        mRemoteChattingManager.getChatMessage(chatRoomId, onSuccessListener, onFailureListener);
+        mRemoteChattingManager.listeningForChangedChatMessage(chatRoomId, onSuccessListener, onFailureListener);
 
     }
 
@@ -284,22 +282,22 @@ public class AppDataManager implements DataManager {
     }
 
     @Override
-    public void setChattingRoom(@NonNull Chatting chatting,
-                                @NonNull OnSuccessListener<Void> onSuccessListener,
+    public void setChattingRoom(@NonNull String destinationUuid,
+                                @NonNull OnSuccessListener<String> onSuccessListener,
                                 @NonNull OnFailureListener onFailureListener) {
 
-        mRemoteChattingManager.setChattingRoom(chatting, onSuccessListener, onFailureListener);
+        mRemoteChattingManager.setChattingRoom(destinationUuid, onSuccessListener, onFailureListener);
     }
 
     @Override
     public void setChatMessage(int messagesLength,
-                               @NonNull String roomUid,
+                               @Nullable String roomUid,
+                               @NonNull String destinationUid,
                                @NonNull String content,
-                               @NonNull OnSuccessListener<Void> onSuccessListener,
+                               @NonNull OnSuccessListener<String> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
 
-        mRemoteChattingManager.setChatMessage(messagesLength, roomUid, content, onSuccessListener, onFailureListener);
-
+        mRemoteChattingManager.setChatMessage(messagesLength, roomUid, destinationUid, content, onSuccessListener, onFailureListener);
     }
 
     @Override

--- a/app/src/main/java/com/swsnack/catchhouse/data/DataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/DataManager.java
@@ -29,5 +29,8 @@ public interface DataManager extends APIManager, UserDataManager, ChattingManage
                           @NonNull OnSuccessListener<Void> onSuccessListener,
                           @NonNull OnFailureListener onFailureListener);
 
-    void deleteUserAll(@NonNull String uuid, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void deleteUserAll(@NonNull String uuid,
+                       @NonNull User user,
+                       @NonNull OnSuccessListener<Void> onSuccessListener,
+                       @NonNull OnFailureListener onFailureListener);
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
@@ -30,10 +30,13 @@ public interface ChattingManager {
 
     void cancelMessageModelObserving();
 
-    void setChattingRoom(@NonNull Chatting chattingUser, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void setChattingRoom(@NonNull Chatting chatting,
+                         @NonNull OnSuccessListener<Void> onSuccessListener,
+                         @NonNull OnFailureListener onFailureListener);
 
-    void setChatMessage(@NonNull String roomUid,
-                        @NonNull Message message,
+    void setChatMessage(int messagesLength,
+                        @NonNull String roomUid,
+                        @NonNull String content,
                         @NonNull OnSuccessListener<Void> onSuccessListener,
                         @NonNull OnFailureListener onFailureListener);
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
@@ -1,6 +1,7 @@
 package com.swsnack.catchhouse.data.chattingdata;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -13,30 +14,30 @@ import java.util.Map;
 
 public interface ChattingManager {
 
-    void getChattingRoom(@NonNull String uuid,
-                         @NonNull String destinationUuid,
+    void getChattingRoom(@NonNull String destinationUuid,
                          @NonNull OnSuccessListener<String> onSuccessListener,
                          @NonNull OnFailureListener onFailureListener);
 
-    void getChattingList(@NonNull String uuid,
-                         @NonNull OnSuccessListener<List<Chatting>> onSuccessListener,
+    void getChattingList(@NonNull OnSuccessListener<List<Chatting>> onSuccessListener,
                          @NonNull OnFailureListener onFailureListener);
 
     void cancelChattingModelObserving();
 
-    void getChatMessage(@NonNull String chatRoomId,
-                        @NonNull OnSuccessListener<List<Message>> onSuccessListener,
-                        @NonNull OnFailureListener onFailureListener);
+    void listeningForChangedChatMessage(@NonNull String chatRoomId,
+                                        @NonNull OnSuccessListener<List<Message>> onSuccessListener,
+                                        @NonNull OnFailureListener onFailureListener);
 
     void cancelMessageModelObserving();
 
-    void setChattingRoom(@NonNull Chatting chatting,
-                         @NonNull OnSuccessListener<Void> onSuccessListener,
+    void setChattingRoom(@NonNull String destinationUuid,
+                         @NonNull OnSuccessListener<String> onSuccessListener,
                          @NonNull OnFailureListener onFailureListener);
 
     void setChatMessage(int messagesLength,
-                        @NonNull String roomUid,
+                        @Nullable String roomUid,
+                        @NonNull String destinationUid,
                         @NonNull String content,
-                        @NonNull OnSuccessListener<Void> onSuccessListener,
+                        @NonNull OnSuccessListener<String> onSuccessListener,
                         @NonNull OnFailureListener onFailureListener);
+
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
@@ -18,12 +18,13 @@ public interface ChattingManager {
     void getChattingList(@NonNull String uuid, @NonNull OnSuccessListener<List<Chatting>> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
     void getChatMessage(@NonNull String chatRoomId,
-                        @NonNull OnSuccessListener<Map<String, Message>> onSuccessListener,
+                        @NonNull OnSuccessListener<List<Message>> onSuccessListener,
                         @NonNull OnFailureListener onFailureListener);
 
     void setChattingRoom(@NonNull Chatting chattingUser, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
-    void setChatMessage(@NonNull Message message,
+    void setChatMessage(@NonNull String roomUid,
+                        @NonNull Message message,
                         @NonNull OnSuccessListener<Void> onSuccessListener,
                         @NonNull OnFailureListener onFailureListener);
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
@@ -9,6 +9,7 @@ import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.data.chattingdata.model.Message;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ChattingManager {
 
@@ -16,9 +17,13 @@ public interface ChattingManager {
 
     void getChattingList(@NonNull String uuid, @NonNull OnSuccessListener<List<Chatting>> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
-    void getChatMessage(@NonNull String chatRoomId, @NonNull ValueEventListener valueEventListener);
+    void getChatMessage(@NonNull String chatRoomId,
+                        @NonNull OnSuccessListener<Map<String, Message>> onSuccessListener,
+                        @NonNull OnFailureListener onFailureListener);
 
     void setChattingRoom(@NonNull Chatting chattingUser, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
-    void setChatMessage(@NonNull Message message, @NonNull ValueEventListener valueEventListener);
+    void setChatMessage(@NonNull Message message,
+                        @NonNull OnSuccessListener<Void> onSuccessListener,
+                        @NonNull OnFailureListener onFailureListener);
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
@@ -13,15 +13,22 @@ import java.util.Map;
 
 public interface ChattingManager {
 
-    void getChattingRoom(@NonNull String uuid, @NonNull String destinationUuid, @NonNull OnSuccessListener<String> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void getChattingRoom(@NonNull String uuid,
+                         @NonNull String destinationUuid,
+                         @NonNull OnSuccessListener<String> onSuccessListener,
+                         @NonNull OnFailureListener onFailureListener);
 
-    void getChattingList(@NonNull String uuid, @NonNull OnSuccessListener<List<Chatting>> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void getChattingList(@NonNull String uuid,
+                         @NonNull OnSuccessListener<List<Chatting>> onSuccessListener,
+                         @NonNull OnFailureListener onFailureListener);
 
-    void removeChattingListListener();
+    void cancelChattingModelObserving();
 
     void getChatMessage(@NonNull String chatRoomId,
                         @NonNull OnSuccessListener<List<Message>> onSuccessListener,
                         @NonNull OnFailureListener onFailureListener);
+
+    void cancelMessageModelObserving();
 
     void setChattingRoom(@NonNull Chatting chattingUser, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/ChattingManager.java
@@ -17,6 +17,8 @@ public interface ChattingManager {
 
     void getChattingList(@NonNull String uuid, @NonNull OnSuccessListener<List<Chatting>> onSuccessListener, @NonNull OnFailureListener onFailureListener);
 
+    void removeChattingListListener();
+
     void getChatMessage(@NonNull String chatRoomId,
                         @NonNull OnSuccessListener<List<Message>> onSuccessListener,
                         @NonNull OnFailureListener onFailureListener);

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/model/Chatting.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/model/Chatting.java
@@ -3,6 +3,7 @@ package com.swsnack.catchhouse.data.chattingdata.model;
 import android.support.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 
 public class Chatting implements Serializable {
@@ -10,7 +11,7 @@ public class Chatting implements Serializable {
     private String roomUid;
     private Map<String, Boolean> users;
     @Nullable
-    private Map<String, Message> message;
+    private List<Message> messages;
 
     public Chatting() {
     }
@@ -25,15 +26,6 @@ public class Chatting implements Serializable {
 
     public void setUsers(Map<String, Boolean> users) {
         this.users = users;
-    }
-
-    @Nullable
-    public Map<String, Message> getMessage() {
-        return message;
-    }
-
-    public void setMessage(@Nullable Map<String, Message> message) {
-        this.message = message;
     }
 
     public String getRoomUid() {
@@ -51,6 +43,15 @@ public class Chatting implements Serializable {
         }
 
         return this.roomUid.equals(((Chatting) obj).getRoomUid());
+    }
+
+    @Nullable
+    public List<Message> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<Message> messages) {
+        this.messages = messages;
     }
 }
 

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/model/Message.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/model/Message.java
@@ -41,4 +41,13 @@ public class Message implements Serializable {
     public void setContent(String content) {
         this.content = content;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(!(obj instanceof Message)) {
+           return false;
+        }
+
+        return this.timestamp.equals(((Message) obj).getTimestamp());
+    }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/remote/RemoteChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/remote/RemoteChattingManager.java
@@ -16,7 +16,9 @@ import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.data.chattingdata.model.Message;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.swsnack.catchhouse.Constant.Chatting.NO_CHAT_ROOM;
 import static com.swsnack.catchhouse.Constant.ExceptionReason.NOT_SIGNED_USER;
@@ -172,24 +174,27 @@ public class RemoteChattingManager implements ChattingManager {
     }
 
     @Override
-    public void setChattingRoom(@NonNull Chatting chattingUser, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
+    public void setChattingRoom(@NonNull Chatting chatting, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener) {
         db
                 .push()
-                .setValue(chattingUser)
+                .setValue(chatting)
                 .addOnSuccessListener(onSuccessListener)
                 .addOnFailureListener(onFailureListener);
     }
 
     @Override
-    public void setChatMessage(@NonNull String roomUid,
-                               @NonNull Message message,
+    public void setChatMessage(int messagesLength,
+                               @NonNull String roomUid,
+                               @NonNull String content,
                                @NonNull OnSuccessListener<Void> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
 
+        Map<String, Object> setMessageField = new HashMap<>();
+        setMessageField.put(String.valueOf(messagesLength + 1), new Message(FirebaseAuth.getInstance().getCurrentUser().getUid(), content));
+
         db.child(roomUid)
                 .child(MESSAGE)
-                .push()
-                .setValue(message)
+                .updateChildren(setMessageField)
                 .addOnSuccessListener(onSuccessListener)
                 .addOnFailureListener(onFailureListener);
     }

--- a/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/remote/RemoteChattingManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/chattingdata/remote/RemoteChattingManager.java
@@ -1,10 +1,12 @@
 package com.swsnack.catchhouse.data.chattingdata.remote;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
@@ -15,12 +17,15 @@ import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.data.chattingdata.model.Message;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.swsnack.catchhouse.Constant.Chatting.NO_CHAT_ROOM;
 import static com.swsnack.catchhouse.Constant.ExceptionReason.NOT_SIGNED_USER;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.CHATTING;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_USER;
+import static com.swsnack.catchhouse.Constant.FirebaseKey.MESSAGE;
 
 public class RemoteChattingManager implements ChattingManager {
 
@@ -109,8 +114,41 @@ public class RemoteChattingManager implements ChattingManager {
     }
 
     @Override
-    public void getChatMessage(@NonNull String chatRoomId, @NonNull ValueEventListener valueEventListener) {
+    public void getChatMessage(@NonNull String chatRoomId,
+                               @NonNull OnSuccessListener<Map<String, Message>> onSuccessListener,
+                               @NonNull OnFailureListener onFailureListener) {
+        db.child(chatRoomId)
+                .child(MESSAGE)
+                .addChildEventListener(new ChildEventListener() {
+                    @Override
+                    public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+                        if (dataSnapshot.getValue() != null) {
+                            Map<String, Message> newMessage = new HashMap<>();
+                            newMessage.put(dataSnapshot.getKey(), dataSnapshot.getValue(Message.class));
+                            onSuccessListener.onSuccess(newMessage);
+                        }
+                    }
 
+                    @Override
+                    public void onChildChanged(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+                        //채팅 메세지 수정기능을 추가하게 될 시, 구현
+                    }
+
+                    @Override
+                    public void onChildRemoved(@NonNull DataSnapshot dataSnapshot) {
+                        //채팅 메세지 수정기능을 추가하게 될 시, 구현
+                    }
+
+                    @Override
+                    public void onChildMoved(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+                        //채팅 메세지 수정기능을 추가하게 될 시, 구현
+                    }
+
+                    @Override
+                    public void onCancelled(@NonNull DatabaseError databaseError) {
+                        onFailureListener.onFailure(databaseError.toException());
+                    }
+                });
     }
 
     @Override
@@ -123,7 +161,9 @@ public class RemoteChattingManager implements ChattingManager {
     }
 
     @Override
-    public void setChatMessage(@NonNull Message message, @NonNull ValueEventListener valueEventListener) {
+    public void setChatMessage(@NonNull Message message,
+                               @NonNull OnSuccessListener<Void> onSuccessListener,
+                               @NonNull OnFailureListener onFailureListener) {
 
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/UserDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/UserDataManager.java
@@ -10,7 +10,6 @@ import com.swsnack.catchhouse.data.roomsdata.pojo.Room;
 import com.swsnack.catchhouse.data.userdata.model.User;
 
 import java.util.List;
-import java.util.Map;
 
 public interface UserDataManager {
 
@@ -22,27 +21,53 @@ public interface UserDataManager {
                                    @NonNull OnSuccessListener<User> onSuccessListener,
                                    @NonNull OnFailureListener onFailureListener);
 
-    void setUser(@NonNull String uuid, @NonNull User user, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void setUser(@NonNull String uuid,
+                 @NonNull User user,
+                 @NonNull OnSuccessListener<Void> onSuccessListener,
+                 @NonNull OnFailureListener onFailureListener);
 
-    void updateUser(@NonNull String uuid, @NonNull Map<String, Object> updateFields, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void setUser(@NonNull String uuid,
+                 @NonNull User user,
+                 @NonNull Uri uri,
+                 @NonNull OnSuccessListener<Void> onSuccessListener,
+                 @NonNull OnFailureListener onFailureListener);
 
-    void updateNickName(@NonNull String uuid, @NonNull String changeNickName, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void updateUser(@NonNull String uuid,
+                    @NonNull User user,
+                    @NonNull OnSuccessListener<Void> onSuccessListener,
+                    @NonNull OnFailureListener onFailureListener);
 
-    void deleteUserData(@NonNull String uuid, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void updateProfile(@NonNull String uuid,
+                       @NonNull Uri uri,
+                       @NonNull User user,
+                       @NonNull OnSuccessListener<Void> onSuccessListener,
+                       @NonNull OnFailureListener onFailureListener);
 
-    void uploadProfile(@NonNull String uuid, @NonNull Uri imageUri, @NonNull OnSuccessListener<Uri> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void deleteUserData(@NonNull String uuid,
+                        @NonNull User user,
+                        @NonNull OnSuccessListener<Void> onSuccessListener,
+                        @NonNull OnFailureListener onFailureListener);
 
-    void getProfile(@NonNull Uri uri, @NonNull OnSuccessListener<Bitmap> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void deleteProfile(@NonNull String uuid,
+                       @NonNull OnSuccessListener<Void> onSuccessListener,
+                       @NonNull OnFailureListener onFailureListener);
 
-    void updateProfile(@NonNull String uuid, @NonNull Uri uri, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void getProfile(@NonNull Uri uri,
+                    @NonNull OnSuccessListener<Bitmap> onSuccessListener,
+                    @NonNull OnFailureListener onFailureListener);
 
-    void deleteProfile(@NonNull String uuid, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void createKey(@NonNull OnSuccessListener<String> onSuccessListener,
+                   @NonNull OnFailureListener onFailureListener);
 
-    void createKey(@NonNull OnSuccessListener<String> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void uploadRoomImage(@NonNull String uuid,
+                         @NonNull List<byte[]> imageList,
+                         @NonNull OnSuccessListener<List<String>> onSuccessListener,
+                         @NonNull OnFailureListener onFailureListener);
 
-    void uploadRoomImage(@NonNull String uuid, @NonNull List<byte[]> imageList, @NonNull OnSuccessListener<List<String>> onSuccessListener, @NonNull OnFailureListener onFailureListener);
-
-    void uploadRoomData(@NonNull String uuid, @NonNull Room room, @NonNull OnSuccessListener<Void> onSuccessListener, @NonNull OnFailureListener onFailureListener);
+    void uploadRoomData(@NonNull String uuid,
+                        @NonNull Room room,
+                        @NonNull OnSuccessListener<Void> onSuccessListener,
+                        @NonNull OnFailureListener onFailureListener);
 
     void findUserByQueryString(@NonNull String queryString,
                                @NonNull String findValue,

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/model/User.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/model/User.java
@@ -85,4 +85,20 @@ public class User implements Parcelable {
     public void setProfile(String profile) {
         this.profile = profile;
     }
+
+    public void setEMail(String eMail) {
+        this.eMail = eMail;
+    }
+
+    public void setNickName(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
+    public void setMyRoom(String myRoom) {
+        this.myRoom = myRoom;
+    }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/model/User.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/model/User.java
@@ -2,9 +2,12 @@ package com.swsnack.catchhouse.data.userdata.model;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.Nullable;
 
 public class User implements Parcelable {
 
+    @Nullable
+    private String uuid;
     private String eMail;
     private String nickName;
     private String gender;
@@ -62,6 +65,15 @@ public class User implements Parcelable {
         dest.writeString(myRoom);
     }
 
+    @Nullable
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
     public String getEMail() {
         return eMail;
     }
@@ -78,27 +90,12 @@ public class User implements Parcelable {
         return profile;
     }
 
-    public String getMyRoom() {
-        return myRoom;
-    }
-
     public void setProfile(String profile) {
         this.profile = profile;
-    }
-
-    public void setEMail(String eMail) {
-        this.eMail = eMail;
     }
 
     public void setNickName(String nickName) {
         this.nickName = nickName;
     }
 
-    public void setGender(String gender) {
-        this.gender = gender;
-    }
-
-    public void setMyRoom(String myRoom) {
-        this.myRoom = myRoom;
-    }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/data/userdata/remote/AppUserDataManager.java
+++ b/app/src/main/java/com/swsnack/catchhouse/data/userdata/remote/AppUserDataManager.java
@@ -11,8 +11,10 @@ import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
+import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseException;
@@ -23,26 +25,34 @@ import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
 import com.swsnack.catchhouse.AppApplication;
+import com.swsnack.catchhouse.data.roomsdata.pojo.Room;
 import com.swsnack.catchhouse.data.userdata.UserDataManager;
 import com.swsnack.catchhouse.data.userdata.model.User;
 import com.swsnack.catchhouse.util.DataConverter;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.swsnack.catchhouse.Constant.ExceptionReason.DUPLICATE;
 import static com.swsnack.catchhouse.Constant.ExceptionReason.DUPLICATE_NICK_NAME;
 import static com.swsnack.catchhouse.Constant.ExceptionReason.FAILED_UPDATE;
 import static com.swsnack.catchhouse.Constant.ExceptionReason.NOT_SIGNED_USER;
+import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_ROOM;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.DB_USER;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.NICK_NAME;
 import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_PROFILE;
+import static com.swsnack.catchhouse.Constant.FirebaseKey.STORAGE_ROOM_IMAGE;
+import static com.swsnack.catchhouse.Constant.PostException.NETWORK_ERROR;
 
 public class AppUserDataManager implements UserDataManager {
 
     private DatabaseReference db;
+    private DatabaseReference dbRooms;
     private StorageReference fs;
+    private StorageReference fsRooms;
     private Application mAppContext;
 
     private static AppUserDataManager INSTANCE;
@@ -56,7 +66,9 @@ public class AppUserDataManager implements UserDataManager {
 
     private AppUserDataManager() {
         db = FirebaseDatabase.getInstance().getReference().child(DB_USER);
+        dbRooms = FirebaseDatabase.getInstance().getReference().child(DB_ROOM);
         fs = FirebaseStorage.getInstance().getReference().child(STORAGE_PROFILE);
+        fsRooms = FirebaseStorage.getInstance().getReference().child(STORAGE_ROOM_IMAGE);
         mAppContext = AppApplication.getAppContext();
     }
 
@@ -252,35 +264,74 @@ public class AppUserDataManager implements UserDataManager {
     }
 
     @Override
-    public void updateUser(@NonNull String uuid,
-                           @NonNull Map<String, Object> updateFields,
-                           @NonNull OnSuccessListener<Void> onSuccessListener,
-                           @NonNull OnFailureListener onFailureListener) {
+    public void createKey(@NonNull OnSuccessListener<String> onSuccessListener,
+                          @NonNull OnFailureListener onFailureListener) {
+        dbRooms.push().addListenerForSingleValueEvent(new ValueEventListener() {
+            @Override
+            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
+                String key = dataSnapshot.getKey();
+                if (key != null) {
+                    onSuccessListener.onSuccess(key);
+                } else {
+                    onFailureListener.onFailure(new RuntimeException(NETWORK_ERROR));
+                }
+            }
 
-        db.child(uuid)
-                .updateChildren(updateFields)
-                .addOnSuccessListener(onSuccessListener)
+            @Override
+            public void onCancelled(@NonNull DatabaseError databaseError) {
+                onFailureListener.onFailure(new RuntimeException(NETWORK_ERROR));
+            }
+        });
+    }
+
+    @Override
+    public void uploadRoomImage(@NonNull String uuid, @NonNull List<byte[]> imageList,
+                                @NonNull OnSuccessListener<List<String>> onSuccessListener,
+                                @NonNull OnFailureListener onFailureListener) {
+
+        List<String> list = new ArrayList<>();
+        List<StorageReference> innerRef = new ArrayList<>();
+        for (int i = 0; i < imageList.size(); i++) {
+            innerRef.add(fsRooms.child(uuid + "/" + i));
+        }
+        UploadTask uploadTask = innerRef.get(0).putBytes(imageList.remove(0));
+
+        Continuation<UploadTask.TaskSnapshot, Task<Uri>> continuation = task -> {
+            if (!task.isSuccessful()) {
+                onFailureListener.onFailure(new RuntimeException(NETWORK_ERROR));
+            }
+            return innerRef.remove(0).getDownloadUrl();
+        };
+
+
+        OnSuccessListener<Uri> loopListener = new OnSuccessListener<Uri>() {
+            @Override
+            public void onSuccess(Uri uri) {
+                list.add(uri.toString());
+
+                if (!imageList.isEmpty()) {
+                    innerRef.get(0).putBytes(imageList.remove(0))
+                            .continueWithTask(continuation)
+                            .addOnSuccessListener(this)
+                            .addOnFailureListener(onFailureListener);
+                } else {
+                    onSuccessListener.onSuccess(list);
+                }
+            }
+        };
+
+        uploadTask
+                .continueWithTask(continuation)
+                .addOnSuccessListener(loopListener)
                 .addOnFailureListener(onFailureListener);
     }
 
     @Override
-    public void updateNickName(@NonNull String uuid,
-                               @NonNull String changeNickName,
+    public void uploadRoomData(@NonNull String uuid, @NonNull Room room,
                                @NonNull OnSuccessListener<Void> onSuccessListener,
                                @NonNull OnFailureListener onFailureListener) {
-
-        findUserByQueryString(NICK_NAME,
-                changeNickName,
-                result -> {
-                    if (result == null) {
-                        Map<String, Object> updateFields = new HashMap<>();
-                        updateFields.put(NICK_NAME, changeNickName);
-                        updateUser(uuid, updateFields, onSuccessListener, onFailureListener);
-                        return;
-                    }
-                    onFailureListener.onFailure(new RuntimeException(DUPLICATE_NICK_NAME));
-                },
-                onFailureListener);
+        dbRooms.child(uuid).setValue(room)
+                .addOnSuccessListener(onSuccessListener)
+                .addOnFailureListener(onFailureListener);
     }
-
 }

--- a/app/src/main/java/com/swsnack/catchhouse/util/DataConverter.java
+++ b/app/src/main/java/com/swsnack/catchhouse/util/DataConverter.java
@@ -2,6 +2,7 @@ package com.swsnack.catchhouse.util;
 
 import android.graphics.Bitmap;
 
+import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.data.chattingdata.model.Message;
 
 import java.io.ByteArrayOutputStream;
@@ -25,19 +26,20 @@ public class DataConverter {
         return byteArrayFromBitmap;
     }
 
-    public static List<Message> sortByValueFromMapToList(Map<String, Message> map) {
-        List<String> keys = new ArrayList<>(map.keySet());
-        List<Message> messages = new ArrayList<>();
+    public static List<Chatting> reOrderedListByTimeStamp(List<Chatting> chattingList) {
+        if(chattingList == null) {
+            return null;
+        }
 
-        Collections.sort(keys, (key1, key2) -> {
-            Message message1 = map.get(key1);
-            Message message2 = map.get(key2);
-            return message1.getTimestamp().compareTo(message2.getTimestamp());
+        Collections.sort(chattingList, (rowIndexChatting, highIndexChatting) -> {
+            Message rowIndexLastMessage = rowIndexChatting.getMessages().get(rowIndexChatting.getMessages().size() - 1);
+            Message highIndexLastMessage = highIndexChatting.getMessages().get(highIndexChatting.getMessages().size() - 1);
+
+            return rowIndexLastMessage.getTimestamp().compareTo(highIndexLastMessage.getTimestamp());
         });
 
-        for (String key : keys) {
-            messages.add(map.get(key));
-        }
-        return messages;
+        Collections.reverse(chattingList);
+
+        return chattingList;
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/util/DataConverter.java
+++ b/app/src/main/java/com/swsnack/catchhouse/util/DataConverter.java
@@ -32,6 +32,10 @@ public class DataConverter {
         }
 
         Collections.sort(chattingList, (rowIndexChatting, highIndexChatting) -> {
+            if(rowIndexChatting.getMessages() == null || highIndexChatting.getMessages() == null) {
+                return 0;
+            }
+
             Message rowIndexLastMessage = rowIndexChatting.getMessages().get(rowIndexChatting.getMessages().size() - 1);
             Message highIndexLastMessage = highIndexChatting.getMessages().get(highIndexChatting.getMessages().size() - 1);
 

--- a/app/src/main/java/com/swsnack/catchhouse/view/BaseFragment.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/BaseFragment.java
@@ -31,6 +31,7 @@ public abstract class BaseFragment<B extends ViewDataBinding, V extends ViewMode
         if (getActivity() != null) {
             if (getViewModelClass() != null) {
                 mViewModel = ViewModelProviders.of(getActivity()).get(getViewModelClass());
+                mBinding.setLifecycleOwner(this);
             }
         } else {
             throw new RuntimeException(this.getClass().getName() + "has null activity");

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/BottomNavActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/BottomNavActivity.java
@@ -52,24 +52,24 @@ public class BottomNavActivity extends BaseActivity<ActivityBottomNavBinding> im
     public void onSuccess(String success) {
         super.onSuccess(success);
         switch (success) {
-            case Constant.UserStatus.SIGN_UP_SUCCESS:
+            case Constant.SuccessKey.SIGN_UP_SUCCESS:
                 mFragmentManager.popBackStack();
                 break;
-            case Constant.UserStatus.SIGN_IN_SUCCESS:
+            case Constant.SuccessKey.SIGN_IN_SUCCESS:
                 /*handle here : when sign in success replace fragment to my page*/
                 mFragmentManager.beginTransaction().replace(R.id.fl_sign_container, new MyPageFragment(), MyPageFragment.class.getName()).commit();
                 break;
-            case Constant.UserStatus.DELETE_USER_SUCCESS:
+            case Constant.SuccessKey.DELETE_USER_SUCCESS:
                 mFragmentManager.beginTransaction().replace(R.id.fl_sign_container, new SignInFragment(), SignInFragment.class.getName()).commit();
                 break;
-            case Constant.UserStatus.UPDATE_PASSWORD_SUCCESS:
+            case Constant.SuccessKey.UPDATE_PASSWORD_SUCCESS:
                 showSnackMessage(getString(R.string.snack_re_sign_in));
                 mFragmentManager.beginTransaction().replace(R.id.fl_sign_container, new SignInFragment(), SignInFragment.class.getName()).commit();
                 break;
-            case Constant.UserStatus.UPDATE_PROFILE_SUCCESS:
+            case Constant.SuccessKey.UPDATE_PROFILE_SUCCESS:
                 showSnackMessage(getString(R.string.snack_update_profile_success));
                 break;
-            case Constant.UserStatus.UPDATE_NICK_NAME_SUCCESS:
+            case Constant.SuccessKey.UPDATE_NICK_NAME_SUCCESS:
                 showSnackMessage(getString(R.string.snack_change_nick_name_success));
                 break;
         }

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
@@ -14,8 +14,10 @@ import com.swsnack.catchhouse.view.BaseActivity;
 import com.swsnack.catchhouse.viewmodel.chattingviewmodel.ChattingViewModel;
 import com.swsnack.catchhouse.viewmodel.chattingviewmodel.ChattingViewModelFactory;
 
+import static com.swsnack.catchhouse.Constant.FirebaseKey.UUID;
 import static com.swsnack.catchhouse.Constant.ParcelableData.CHATTING_DATA;
 import static com.swsnack.catchhouse.Constant.ParcelableData.USER_DATA;
+import static com.swsnack.catchhouse.Constant.SuccessKey.SEND_MESSAGE_SUCCESS;
 
 public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessageBinding> {
 
@@ -25,7 +27,7 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
     public void onSuccess(String success) {
         super.onSuccess(success);
 
-        if (success.equals("sendSuccess")) {
+        if (success.equals(SEND_MESSAGE_SUCCESS)) {
             getBinding().etChattingMessageContent.setText("");
         }
     }
@@ -44,6 +46,11 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
                 && getIntent().getSerializableExtra(CHATTING_DATA) != null) {
             mViewModel.setChattingMessage((Chatting) getIntent().getSerializableExtra(CHATTING_DATA));
             mViewModel.setDestinationUserData(getIntent().getParcelableExtra(USER_DATA));
+        } else if(getIntent().getStringExtra(UUID) != null){
+            // set dummy data
+            mViewModel.setDestinationUuid("Ma1jLM8hj7NVmBVHlU2P7NIrrvu1");
+        } else {
+            throw new RuntimeException("chatting destination user's not exist");
         }
 
         ChattingMessageAdapter messageAdapter = new ChattingMessageAdapter(getApplicationContext(), mViewModel);
@@ -52,8 +59,10 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
 
         getBinding().etChattingMessageContent.setOnKeyListener((v, keyCode, event) -> {
             if ((event.getAction() == KeyEvent.ACTION_DOWN) && keyCode == KeyEvent.KEYCODE_ENTER) {
+                if(getBinding().etChattingMessageContent.getText().toString().trim().equals("")) {
+                    return true;
+                }
                 mViewModel.sendNewMessage(messageAdapter.getItemCount(), getBinding().etChattingMessageContent.getText().toString());
-                getBinding().etChattingMessageContent.setText("");
                 return true;
             }
             return false;
@@ -79,5 +88,9 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
         getBinding().setLifecycleOwner(this);
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
 
+    }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
@@ -52,7 +52,7 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
 
         getBinding().etChattingMessageContent.setOnKeyListener((v, keyCode, event) -> {
             if ((event.getAction() == KeyEvent.ACTION_DOWN) && keyCode == KeyEvent.KEYCODE_ENTER) {
-                mViewModel.sendNewMessage(getBinding().etChattingMessageContent.getText().toString());
+                mViewModel.sendNewMessage(messageAdapter.getItemCount(), getBinding().etChattingMessageContent.getText().toString());
                 getBinding().etChattingMessageContent.setText("");
                 return true;
             }

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
@@ -68,4 +68,11 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
         getBinding().setHandler(mViewModel);
         getBinding().setLifecycleOwner(this);
     }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        mViewModel.setDestinationUserData(null);
+        mViewModel.setChattingMessage(null);
+    }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
@@ -3,6 +3,7 @@ package com.swsnack.catchhouse.view.activitity;
 import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
+import android.view.KeyEvent;
 import android.widget.LinearLayout;
 
 import com.swsnack.catchhouse.R;
@@ -10,35 +11,23 @@ import com.swsnack.catchhouse.adapter.chattingadapter.ChattingMessageAdapter;
 import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.databinding.ActivityChattingMessageBinding;
 import com.swsnack.catchhouse.view.BaseActivity;
-import com.swsnack.catchhouse.viewmodel.ViewModelListener;
 import com.swsnack.catchhouse.viewmodel.chattingviewmodel.ChattingViewModel;
 import com.swsnack.catchhouse.viewmodel.chattingviewmodel.ChattingViewModelFactory;
 
 import static com.swsnack.catchhouse.Constant.ParcelableData.CHATTING_DATA;
 import static com.swsnack.catchhouse.Constant.ParcelableData.USER_DATA;
 
-public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessageBinding> implements ViewModelListener {
+public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessageBinding> {
 
     private ChattingViewModel mViewModel;
 
     @Override
-    public void onError(String errorMessage) {
-
-    }
-
-    @Override
     public void onSuccess(String success) {
+        super.onSuccess(success);
 
-    }
-
-    @Override
-    public void isWorking() {
-
-    }
-
-    @Override
-    public void isFinished() {
-
+        if (success.equals("sendSuccess")) {
+            getBinding().etChattingMessageContent.setText("");
+        }
     }
 
     @Override
@@ -57,9 +46,20 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
             mViewModel.setDestinationUserData(getIntent().getParcelableExtra(USER_DATA));
         }
 
+        mViewModel.getNewMessage();
+
         ChattingMessageAdapter messageAdapter = new ChattingMessageAdapter(getApplicationContext(), mViewModel);
         getBinding().rvChattingMessage.setAdapter(messageAdapter);
         getBinding().rvChattingMessage.setLayoutManager(new LinearLayoutManager(getApplicationContext(), LinearLayout.VERTICAL, false));
+
+        getBinding().etChattingMessageContent.setOnKeyListener((v, keyCode, event) -> {
+            if ((event.getAction() == KeyEvent.ACTION_DOWN) && keyCode == KeyEvent.KEYCODE_ENTER) {
+                mViewModel.sendNewMessage(getBinding().etChattingMessageContent.getText().toString());
+                getBinding().etChattingMessageContent.setText("");
+                return true;
+            }
+            return false;
+        });
 
     }
 
@@ -69,10 +69,4 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
         getBinding().setLifecycleOwner(this);
     }
 
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mViewModel.setDestinationUserData(null);
-        mViewModel.setChattingMessage(null);
-    }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/activitity/ChattingMessageActivity.java
@@ -46,8 +46,6 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
             mViewModel.setDestinationUserData(getIntent().getParcelableExtra(USER_DATA));
         }
 
-        mViewModel.getNewMessage();
-
         ChattingMessageAdapter messageAdapter = new ChattingMessageAdapter(getApplicationContext(), mViewModel);
         getBinding().rvChattingMessage.setAdapter(messageAdapter);
         getBinding().rvChattingMessage.setLayoutManager(new LinearLayoutManager(getApplicationContext(), LinearLayout.VERTICAL, false));
@@ -63,10 +61,23 @@ public class ChattingMessageActivity extends BaseActivity<ActivityChattingMessag
 
     }
 
+    @Override
+    protected void onStart() {
+        super.onStart();
+        mViewModel.getNewMessage();
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        mViewModel.cancelChangingMessagesListening();
+    }
+
     private void init() {
         mViewModel = ViewModelProviders.of(this, new ChattingViewModelFactory(this)).get(ChattingViewModel.class);
         getBinding().setHandler(mViewModel);
         getBinding().setLifecycleOwner(this);
     }
+
 
 }

--- a/app/src/main/java/com/swsnack/catchhouse/view/fragment/ChatListFragment.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/fragment/ChatListFragment.java
@@ -68,6 +68,7 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
                             .putExtra(USER_DATA, user));
         });
 
+        getViewModel().setChattingRoom();
     }
 
     @Override
@@ -79,13 +80,13 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
     @Override
     public void onStop() {
         super.onStop();
-        getViewModel().cancelChattingListChangingListeneing();
+        getViewModel().cancelChattingListChangingListening();
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mViewModel.cancelChattingListChangingListeneing();
+        mViewModel.cancelChattingListChangingListening();
     }
 
     public void getChattingList() {

--- a/app/src/main/java/com/swsnack/catchhouse/view/fragment/ChatListFragment.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/fragment/ChatListFragment.java
@@ -68,7 +68,24 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
                             .putExtra(USER_DATA, user));
         });
 
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
         getViewModel().getChattingRoomList();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        getViewModel().cancelChattingListChangingListeneing();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mViewModel.cancelChattingListChangingListeneing();
     }
 
     public void getChattingList() {
@@ -78,11 +95,5 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
         } else {
             getBinding().tvChatListNotSigned.setVisibility(View.GONE);
         }
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        mViewModel.removeListenerForChattingList();
     }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/view/fragment/ChatListFragment.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/fragment/ChatListFragment.java
@@ -24,6 +24,7 @@ import com.swsnack.catchhouse.viewmodel.chattingviewmodel.ChattingViewModel;
 import java.util.ArrayList;
 import java.util.Objects;
 
+import static com.swsnack.catchhouse.Constant.FirebaseKey.UUID;
 import static com.swsnack.catchhouse.Constant.ParcelableData.CHATTING_DATA;
 import static com.swsnack.catchhouse.Constant.ParcelableData.USER_DATA;
 
@@ -61,14 +62,19 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
             Chatting chatting = chattingListAdapter.getItem(position);
             User user = ((ChattingListItemHolder) v).getBinding().getUserData();
 
-            getActivity().startActivity(
+            startActivity(
                     new Intent(getContext(),
                             ChattingMessageActivity.class)
                             .putExtra(CHATTING_DATA, chatting)
                             .putExtra(USER_DATA, user));
         });
 
-        getViewModel().setChattingRoom();
+        getBinding().test.setOnClickListener(v -> {
+            Intent intent = new Intent(getContext(), ChattingMessageActivity.class);
+            // set dummy data
+            intent.putExtra(UUID, "dd");
+            startActivity(intent);
+        });
     }
 
     @Override

--- a/app/src/main/java/com/swsnack/catchhouse/view/fragment/ChatListFragment.java
+++ b/app/src/main/java/com/swsnack/catchhouse/view/fragment/ChatListFragment.java
@@ -6,15 +6,13 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.swsnack.catchhouse.R;
-import com.swsnack.catchhouse.adapter.chattingadapter.ChattingListItemHolder;
 import com.swsnack.catchhouse.adapter.chattingadapter.ChattingListAdapter;
+import com.swsnack.catchhouse.adapter.chattingadapter.ChattingListItemHolder;
 import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.data.userdata.model.User;
 import com.swsnack.catchhouse.databinding.FragmentChatListBinding;
@@ -50,23 +48,10 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-    }
-
-    @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        super.onCreateView(inflater, container, savedInstanceState);
-        return getBinding().getRoot();
-    }
-
-    @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         getBinding().setHandler(getViewModel());
-        getBinding().setLifecycleOwner(this);
 
         ChattingListAdapter chattingListAdapter = new ChattingListAdapter(getContext(), getViewModel());
         getBinding().rvChatList.setAdapter(chattingListAdapter);
@@ -83,6 +68,7 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
                             .putExtra(USER_DATA, user));
         });
 
+        getViewModel().getChattingRoomList();
     }
 
     public void getChattingList() {
@@ -91,10 +77,12 @@ public class ChatListFragment extends BaseFragment<FragmentChatListBinding, Chat
             getViewModel().setChattingList(new ArrayList<>());
         } else {
             getBinding().tvChatListNotSigned.setVisibility(View.GONE);
-            /* set dummy data*/
-            getViewModel().getChattingRoomList();
-            getViewModel().setChattingRoom();
         }
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mViewModel.removeListenerForChattingList();
+    }
 }

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
@@ -13,7 +13,6 @@ import com.swsnack.catchhouse.data.DataManager;
 import com.swsnack.catchhouse.data.chattingdata.model.Chatting;
 import com.swsnack.catchhouse.data.chattingdata.model.Message;
 import com.swsnack.catchhouse.data.userdata.model.User;
-import com.swsnack.catchhouse.util.DataConverter;
 import com.swsnack.catchhouse.util.StringUtil;
 import com.swsnack.catchhouse.viewmodel.ReactiveViewModel;
 import com.swsnack.catchhouse.viewmodel.ViewModelListener;
@@ -52,7 +51,7 @@ public class ChattingViewModel extends ReactiveViewModel {
                         error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_database_exception)));
     }
 
-    public void cancelChattingListChangingListeneing() {
+    public void cancelChattingListChangingListening() {
         getDataManager()
                 .cancelChattingModelObserving();
     }
@@ -64,11 +63,17 @@ public class ChattingViewModel extends ReactiveViewModel {
         }
         mListener.isWorking();
 
+        //set dummy data
+        List<Message> messages = new ArrayList<>();
+        messages.add(new Message("RvXHEN2wXAMDQRvjQkgrfL0rWOC3", "dd"));
+        messages.add(new Message("RvXHEN2wXAMDQRvjQkgrfL0rWOC3", "dd"));
+
         /* dummy data for testing*/
         users.put(FirebaseAuth.getInstance().getCurrentUser().getUid(), true);
         users.put("RvXHEN2wXAMDQRvjQkgrfL0rWOC3", true);
 
         Chatting chatting = new Chatting(users);
+        chatting.setMessages(messages);
         getDataManager()
                 .setChattingRoom(chatting,
                         success -> mListener.isFinished(),
@@ -86,14 +91,13 @@ public class ChattingViewModel extends ReactiveViewModel {
                 return;
             }
         }
-
     }
 
     public void getNewMessage() {
         getDataManager()
                 .getChatMessage(roomUid,
                         messageList -> mMessageList.setValue(messageList),
-                        error -> mListener.onError(""));
+                        error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_failed_load_list)));
     }
 
     public void cancelChangingMessagesListening() {
@@ -101,11 +105,12 @@ public class ChattingViewModel extends ReactiveViewModel {
                 .cancelMessageModelObserving();
     }
 
-    public void sendNewMessage(String content) {
+    public void sendNewMessage(int messagesLength, String content) {
         getDataManager()
-                .setChatMessage(roomUid, new Message(FirebaseAuth.getInstance().getCurrentUser().getUid(), content),
-                        success -> mListener.onSuccess("sendSuccess"),
-                        error -> mListener.onError(""));
+                .setChatMessage(messagesLength, roomUid, content,
+                        success -> {
+                        },
+                        error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_failed_send_message)));
     }
 
     public LiveData<List<Chatting>> getChattingList() {
@@ -120,11 +125,11 @@ public class ChattingViewModel extends ReactiveViewModel {
         return mMessageList;
     }
 
-    public void setChattingMessage(Chatting chattingMessage) {
-        if (chattingMessage != null) {
-            roomUid = chattingMessage.getRoomUid();
-            if (chattingMessage.getMessage() != null) {
-                this.mMessageList.setValue(DataConverter.sortByValueFromMapToList(chattingMessage.getMessage()));
+    public void setChattingMessage(Chatting chatting) {
+        if (chatting != null) {
+            roomUid = chatting.getRoomUid();
+            if (chatting.getMessages() != null) {
+                this.mMessageList.setValue(chatting.getMessages());
             }
             return;
         }

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
@@ -52,7 +52,7 @@ public class ChattingViewModel extends ReactiveViewModel {
                         error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_database_exception)));
     }
 
-    public void removeListenerForChattingList() {
+    public void cancelChattingListChangingListeneing() {
         getDataManager()
                 .cancelChattingModelObserving();
     }
@@ -94,6 +94,11 @@ public class ChattingViewModel extends ReactiveViewModel {
                 .getChatMessage(roomUid,
                         messageList -> mMessageList.setValue(messageList),
                         error -> mListener.onError(""));
+    }
+
+    public void cancelChangingMessagesListening() {
+        getDataManager()
+                .cancelMessageModelObserving();
     }
 
     public void sendNewMessage(String content) {

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
@@ -23,9 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.swsnack.catchhouse.Constant.FacebookData.KEY;
-import static com.swsnack.catchhouse.Constant.FirebaseKey.MESSAGE;
-
 public class ChattingViewModel extends ReactiveViewModel {
 
     private Application mAppContext;
@@ -53,6 +50,11 @@ public class ChattingViewModel extends ReactiveViewModel {
                 .getChattingList(FirebaseAuth.getInstance().getCurrentUser().getUid(),
                         list -> mChattingList.setValue(list),
                         error -> mListener.onError(StringUtil.getStringFromResource(R.string.snack_database_exception)));
+    }
+
+    public void removeListenerForChattingList() {
+        getDataManager()
+                .removeChattingListListener();
     }
 
     public void setChattingRoom() {

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/chattingviewmodel/ChattingViewModel.java
@@ -54,7 +54,7 @@ public class ChattingViewModel extends ReactiveViewModel {
 
     public void removeListenerForChattingList() {
         getDataManager()
-                .removeChattingListListener();
+                .cancelChattingModelObserving();
     }
 
     public void setChattingRoom() {
@@ -116,9 +116,11 @@ public class ChattingViewModel extends ReactiveViewModel {
     }
 
     public void setChattingMessage(Chatting chattingMessage) {
-        if (chattingMessage != null && chattingMessage.getMessage() != null) {
+        if (chattingMessage != null) {
             roomUid = chattingMessage.getRoomUid();
-            this.mMessageList.setValue(DataConverter.sortByValueFromMapToList(chattingMessage.getMessage()));
+            if (chattingMessage.getMessage() != null) {
+                this.mMessageList.setValue(DataConverter.sortByValueFromMapToList(chattingMessage.getMessage()));
+            }
             return;
         }
         mMessageList.setValue(new ArrayList<>());

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/userviewmodel/UserViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/userviewmodel/UserViewModel.java
@@ -40,6 +40,7 @@ public class UserViewModel extends ReactiveViewModel {
     private ViewModelListener mListener;
     private Uri mProfileUri;
     private MutableLiveData<String> mGender;
+    private User mUser;
     public MutableLiveData<Boolean> mIsSigned;
     public MutableLiveData<String> mEmail;
     public MutableLiveData<String> mPassword;
@@ -91,6 +92,7 @@ public class UserViewModel extends ReactiveViewModel {
                             if (user == null) {
                                 return;
                             }
+                            mUser = user;
                             mEmail.setValue(user.getEMail());
                             mNickName.setValue(user.getNickName());
                             mGender.setValue(user.getGender());
@@ -201,10 +203,12 @@ public class UserViewModel extends ReactiveViewModel {
 
         String uuid = FirebaseAuth.getInstance().getCurrentUser().getUid();
         getDataManager()
-                .deleteUserAll(uuid, deleteResult -> {
-                    mListener.onSuccess(DELETE_USER_SUCCESS);
-                    mIsSigned.setValue(false);
-                }, error -> mListener.onError(getStringFromResource(R.string.snack_error_occured)));
+                .deleteUserAll(uuid, mUser,
+                        deleteResult -> {
+                            mListener.onSuccess(DELETE_USER_SUCCESS);
+                            mIsSigned.setValue(false);
+                        },
+                        error -> mListener.onError(getStringFromResource(R.string.snack_error_occured)));
     }
 
     public void changeNickName(String changeNickName) {
@@ -213,9 +217,10 @@ public class UserViewModel extends ReactiveViewModel {
             return;
         }
 
+        mUser.setNickName(changeNickName);
         getDataManager()
-                .updateNickName(FirebaseAuth.getInstance().getCurrentUser().getUid(),
-                        changeNickName,
+                .updateUser(FirebaseAuth.getInstance().getCurrentUser().getUid(),
+                        mUser,
                         success -> mListener.onSuccess(UPDATE_NICK_NAME_SUCCESS),
                         error -> mListener.onError(getStringFromResource(R.string.snack_duplicate_nick_name)));
     }
@@ -230,7 +235,7 @@ public class UserViewModel extends ReactiveViewModel {
     public void updateProfile(Uri uri) {
         mListener.isWorking();
         getDataManager().
-                updateProfile(FirebaseAuth.getInstance().getCurrentUser().getUid(), uri,
+                updateProfile(FirebaseAuth.getInstance().getCurrentUser().getUid(), uri, mUser,
                         result -> mListener.onSuccess(UPDATE_PROFILE_SUCCESS),
                         error -> mListener.onError(getStringFromResource(R.string.snack_update_profile_failed)));
     }

--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/userviewmodel/UserViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/userviewmodel/UserViewModel.java
@@ -27,12 +27,12 @@ import com.swsnack.catchhouse.util.StringUtil;
 import com.swsnack.catchhouse.viewmodel.ReactiveViewModel;
 import com.swsnack.catchhouse.viewmodel.ViewModelListener;
 
-import static com.swsnack.catchhouse.Constant.UserStatus.DELETE_USER_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.SIGN_IN_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.SIGN_UP_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.UPDATE_NICK_NAME_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.UPDATE_PASSWORD_SUCCESS;
-import static com.swsnack.catchhouse.Constant.UserStatus.UPDATE_PROFILE_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.DELETE_USER_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.SIGN_IN_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.SIGN_UP_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.UPDATE_NICK_NAME_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.UPDATE_PASSWORD_SUCCESS;
+import static com.swsnack.catchhouse.Constant.SuccessKey.UPDATE_PROFILE_SUCCESS;
 
 public class UserViewModel extends ReactiveViewModel {
 

--- a/app/src/main/res/layout/fragment_chat_list.xml
+++ b/app/src/main/res/layout/fragment_chat_list.xml
@@ -37,7 +37,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="true"
-                bind:setList="@{handler.chattingList}" />
+                bind:setChattingList="@{handler.chattingList}" />
 
             <TextView
                 android:id="@+id/tv_chat_list_not_signed"

--- a/app/src/main/res/layout/fragment_chat_list.xml
+++ b/app/src/main/res/layout/fragment_chat_list.xml
@@ -49,6 +49,13 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <Button
+                android:id="@+id/test"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"/>
+
         </android.support.constraint.ConstraintLayout>
 
     </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_chatting_list.xml
+++ b/app/src/main/res/layout/item_chatting_list.xml
@@ -41,7 +41,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    bind:setChattingListProfile="@{userData}" />
+                    bind:setChattingUserProfile="@{userData}" />
 
                 <TextView
                     android:id="@+id/tv_chatting_list_item_nick_name"

--- a/app/src/main/res/layout/item_chatting_message.xml
+++ b/app/src/main/res/layout/item_chatting_message.xml
@@ -28,7 +28,7 @@
             style="@style/iv.round"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            bind:setChattingListProfile="@{userData}" />
+            bind:setChattingUserProfile="@{userData}" />
 
         <TextView
             android:id="@+id/tv_item_message_destination"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     /* fragment_chatting_list*/
     <string name="snack_failed_make_chattingRoom">채팅방 개설에 실패했습니다.</string>
     <string name="snack_failed_load_list">조회 실패했습니다.</string>
+    <string name="snack_failed_send_message">메세지 전송에 실패했습니다.</string>
 
     /* activity_post */
     <string name="tb_post">매물 상세 정보</string>


### PR DESCRIPTION
## 개요
- 채팅 기능 구현 및, data패키지의 userManager 가독성 향상

## 구현사항
-  dummy data와 채팅 가능
-  ChattingFragment 하단 버튼은 dummy 데이터 생성.
-  채팅 리스트에서 timeStamp에 따라, diffUtil 갱신
-  같은 유저와의 채팅 시, 두개의 채팅방을 생성하지 않고, 하나의 채팅방 사용
-  ChattingActivity 내에서 채팅을 시작하기 전까지 채팅방 개설하지 않음
-  실시간 채팅시, RecyclerView에 최신 데이터 실시간 반영.

## 리뷰 요청사항
- 


resolve: #59 
