### PR TITLE
로그아웃 후, 매물 검색시 앱 크래쉬 오류 해결

### DIFF
--- a/app/src/main/java/com/swsnack/catchhouse/viewmodel/postviewmodel/PostViewModel.java
+++ b/app/src/main/java/com/swsnack/catchhouse/viewmodel/postviewmodel/PostViewModel.java
@@ -168,6 +168,9 @@ public class PostViewModel extends ReactiveViewModel {
     }
 
     private boolean checkIsWriter(String uuid) {
+        if(FirebaseAuth.getInstance().getCurrentUser() == null) {
+            return false;
+        }
         String myKey = FirebaseAuth.getInstance().getCurrentUser().getUid();
 
         return TextUtils.equals(uuid, myKey);


### PR DESCRIPTION
로그아웃 후, 매물 정보 볼때 NPE 에러 해결

## 개요
- 로그아웃 후, 매물 검색시 앱 크래쉬 오류 해결


## 구현사항
- Firebase 로그아웃시, uuid null참조. NPE 해결


## 리뷰 요청사항
- 


resolve: #147 
